### PR TITLE
Add postinstall_script to symlink the 'github' CLI tool

### DIFF
--- a/Github/Github.munki.recipe
+++ b/Github/Github.munki.recipe
@@ -22,8 +22,29 @@
             <string>GitHub</string>
             <key>name</key>
             <string>%NAME%</string>
+            <key>postinstall_script</key>
+            <string>#!/bin/sh
+            CLI_SOURCE="/Applications/GitHub.app/Contents/MacOS/github_cli"
+            DEST_DIR="/usr/local/bin"
+            if [ ! -x "${CLI_SOURCE}" ]; then
+                exit 1
+            fi
+
+            if [ ! -d "${DEST_DIR}" ]; then
+                /bin/mkdir -p "${DEST_DIR}"
+            fi
+
+            /bin/ln -sf "${CLI_SOURCE}" "${DEST_DIR}/github"
+            </string>
             <key>unattended_install</key>
             <true/>
+            <key>uninstall_method</key>
+            <string>uninstall_script</string>
+            <key>uninstall_script</key>
+            <string>#!/bin/sh
+            /bin/rm -rf /Applications/GitHub.app
+            /bin/rm -f /usr/local/bin/github
+            </string>
         </dict>
     </dict>
     <key>MinimumVersion</key>

--- a/Github/Github.munki.recipe
+++ b/Github/Github.munki.recipe
@@ -24,27 +24,27 @@
             <string>%NAME%</string>
             <key>postinstall_script</key>
             <string>#!/bin/sh
-            CLI_SOURCE="/Applications/GitHub.app/Contents/MacOS/github_cli"
-            DEST_DIR="/usr/local/bin"
-            if [ ! -x "${CLI_SOURCE}" ]; then
-                exit 1
-            fi
+CLI_SOURCE="/Applications/GitHub.app/Contents/MacOS/github_cli"
+DEST_DIR="/usr/local/bin"
+if [ ! -x "${CLI_SOURCE}" ]; then
+    exit 1
+fi
 
-            if [ ! -d "${DEST_DIR}" ]; then
-                /bin/mkdir -p "${DEST_DIR}"
-            fi
+if [ ! -d "${DEST_DIR}" ]; then
+    /bin/mkdir -p "${DEST_DIR}"
+fi
 
-            /bin/ln -sf "${CLI_SOURCE}" "${DEST_DIR}/github"
-            </string>
+/bin/ln -sf "${CLI_SOURCE}" "${DEST_DIR}/github"
+</string>
             <key>unattended_install</key>
             <true/>
             <key>uninstall_method</key>
             <string>uninstall_script</string>
             <key>uninstall_script</key>
             <string>#!/bin/sh
-            /bin/rm -rf /Applications/GitHub.app
-            /bin/rm -f /usr/local/bin/github
-            </string>
+/bin/rm -rf /Applications/GitHub.app
+/bin/rm -f /usr/local/bin/github
+</string>
         </dict>
     </dict>
     <key>MinimumVersion</key>

--- a/Github/Github.munki.recipe
+++ b/Github/Github.munki.recipe
@@ -34,7 +34,7 @@ if [ ! -d "${DEST_DIR}" ]; then
     /bin/mkdir -p "${DEST_DIR}"
 fi
 
-/bin/ln -sf "${CLI_SOURCE}" "${DEST_DIR}/github"
+/bin/cp -f "${CLI_SOURCE}" "${DEST_DIR}/github"
 </string>
             <key>unattended_install</key>
             <true/>


### PR DESCRIPTION
This seems to prevent the privileged helper tool prompt for admin credentials when GitHub is first launched.