### PR TITLE
New Opera Recipe

### DIFF
--- a/Opera/Opera.download.recipe
+++ b/Opera/Opera.download.recipe
@@ -12,7 +12,7 @@
         <string>Opera</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>0.2.1</string>
     <key>Process</key>
     <array>
         <dict>

--- a/Opera/Opera.download.recipe
+++ b/Opera/Opera.download.recipe
@@ -2,35 +2,32 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+    <key>Description</key>
+    <string>Downloads latest Opera disk image.</string>
+    <key>Identifier</key>
+    <string>com.github.keeleysam.download.Opera</string>
     <key>Input</key>
     <dict>
-        <key>IDENTIFIER</key>
-        <string>com.github.keeleysam.recipes.Opera.download</string>
         <key>NAME</key>
         <string>Opera</string>
-        <key>DOWNLOAD_URL</key>
-        <string>http://www.opera.com/download/get/?id=35929&amp;location=360&amp;nothanks=yes&amp;sub=marine</string>
-        <key>USER_AGENT</key>
-        <string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_3) AppleWebKit/536.28.10 (KHTML, like Gecko) Version/6.0.3 Safari/536.28.10</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.1</string>
+    <string>0.2.0</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>OperaURLProvider</string>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>URLDownloader</string>
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>%DOWNLOAD_URL%</string>
+                <string>%url%</string>
                 <key>filename</key>
                 <string>%NAME%.dmg</string>
-                <key>request_headers</key>
-                <dict>
-                        <key>user-agent</key>
-                        <string>%USER_AGENT%</string>
-                </dict>
             </dict>
         </dict>
         <dict>

--- a/Opera/Opera.download.recipe
+++ b/Opera/Opera.download.recipe
@@ -5,7 +5,7 @@
     <key>Description</key>
     <string>Downloads latest Opera disk image.</string>
     <key>Identifier</key>
-    <string>com.github.keeleysam.download.Opera</string>
+    <string>com.github.keeleysam.recipes.Opera.download</string>
     <key>Input</key>
     <dict>
         <key>NAME</key>

--- a/Opera/Opera.munki.recipe
+++ b/Opera/Opera.munki.recipe
@@ -2,14 +2,16 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+    <key>Description</key>
+    <string>Downloads the latest Opera disk image and imports into Munki.</string>
+    <key>Identifier</key>
+    <string>com.github.keeleysam.recipes.Opera.munki</string>
     <key>Input</key>
     <dict>
-        <key>IDENTIFIER</key>
-        <string>com.github.keeleysam.recipes.Opera.munki</string>
         <key>NAME</key>
         <string>Opera</string>
         <key>MUNKI_REPO_SUBDIR</key>
-        <string>apps/Opera</string>
+         <string>apps/Opera</string>
         <key>pkginfo</key>
         <dict>
             <key>catalogs</key>
@@ -17,7 +19,7 @@
                 <string>testing</string>
             </array>
             <key>description</key>
-            <string>A web browser.</string>
+            <string>Opera products enable more than 350 million internet consumers to discover and connect with the content and services that matter most to them, no matter what device, network or location. In turn, we help advertisers reach the audiences that build value for their businesses. Opera also delivers products and services to more than 120 operators around the world, enabling them to provide a faster, more economical and better network experience to their subscribers.</string>
             <key>display_name</key>
             <string>Opera</string>
             <key>name</key>
@@ -27,16 +29,16 @@
         </dict>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.1</string>
+    <string>0.2.0</string>
     <key>ParentRecipe</key>
-    <string>com.github.keeleysam.recipes.Opera.download</string>
+    <string>com.github.keeleysam.download.Opera</string>
     <key>Process</key>
     <array>
         <dict>
             <key>Arguments</key>
             <dict>
                 <key>pkg_path</key>
-                <string>%pathname%</string>
+                <string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
                 <key>repo_subdirectory</key>
                 <string>%MUNKI_REPO_SUBDIR%</string>
             </dict>

--- a/Opera/Opera.munki.recipe
+++ b/Opera/Opera.munki.recipe
@@ -11,7 +11,7 @@
         <key>NAME</key>
         <string>Opera</string>
         <key>MUNKI_REPO_SUBDIR</key>
-         <string>apps/Opera</string>
+        <string>apps/Opera</string>
         <key>pkginfo</key>
         <dict>
             <key>catalogs</key>

--- a/Opera/Opera.munki.recipe
+++ b/Opera/Opera.munki.recipe
@@ -31,7 +31,7 @@
     <key>MinimumVersion</key>
     <string>0.2.0</string>
     <key>ParentRecipe</key>
-    <string>com.github.keeleysam.download.Opera</string>
+    <string>com.github.keeleysam.recipes.Opera.download</string>
     <key>Process</key>
     <array>
         <dict>

--- a/Opera/OperaURLProvider.py
+++ b/Opera/OperaURLProvider.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+#
+# Copyright 2014 Nick Gamewell
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+import urllib2
+
+from autopkglib import Processor, ProcessorError
+
+
+__all__ = ["OperaURLProvider"]
+
+
+BASE_URL = "http://get.geo.opera.com/ftp/pub/opera/desktop/"
+
+
+class OperaURLProvider(Processor):
+    """Provides a download URL for the latest Opera release."""
+    input_variables = {
+        "base_url": {
+            "required": False,
+            "description": "Default is %s" % BASE_URL,
+        },
+    }
+    output_variables = {
+        "url": {
+            "description": "URL to the latest Opera release.",
+        },
+    }
+    description = __doc__
+
+    def get_opera_url(self, url):
+        try:
+        	page = urllib2.urlopen(url).read()
+        	links = re.findall("<a.*?\s*href=\"(.*?)\".*?>", page)
+        	url += max(links) + "mac/"
+
+        	page = urllib2.urlopen(url).read()
+        	links = re.findall("<a.*?\s*href=\"(.*?)\".*?>", page)
+        	for link in links:
+        		if ".dmg" in link:
+        			url += link
+        	return url
+        except BaseException as err:
+        	raise Exception("Can't read %s: %s" % (base_url, err))
+        
+    def main(self):
+        """Find and return a download URL"""
+        base_url = self.env.get("base_url", BASE_URL)
+        self.env["url"] = self.get_opera_url(base_url)
+        self.output("Found URL %s" % self.env["url"])
+
+if __name__ == "__main__":
+    processor = OperaURLProvider()
+    processor.execute_shell()


### PR DESCRIPTION
I've created a new Opera Recipe \ Processor.  It retrieves the download URL from the public ftp located here: http://get.geo.opera.com/ftp/pub/opera/desktop/ As opposed to the download link on the homepage.  This gives the advantage that the download URL is less likely to go out of date.  The current processor downloads Opera 15 when version 24 is current