### PR TITLE
Ccc4 url+pkg&install recipes

### DIFF
--- a/CarbonCopyCloner/CarbonCopyCloner.download.recipe
+++ b/CarbonCopyCloner/CarbonCopyCloner.download.recipe
@@ -11,10 +11,12 @@
         <key>NAME</key>
         <string>CarbonCopyCloner</string>
         <key>SPARKLE_FEED_URL</key>
-        <string>http://www.bombich.com/software/updates/ccc.xml</string>
+        <string>http://www.bombich.com/software/updates/ccc-4.xml</string>
+        <key>USER_AGENT</key>
+        <string>Carbon Copy Cloner (Mac OS X) Sparkle/1.0</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>0.3.1</string>
     <key>Process</key>
     <array>
         <dict>
@@ -24,6 +26,11 @@
             <dict>
                 <key>appcast_url</key>
                 <string>%SPARKLE_FEED_URL%</string>
+                <key>appcast_request_headers</key>
+                <dict>
+                    <key>user-agent</key>
+                    <string>%USER_AGENT%</string>
+                </dict>
             </dict>
         </dict>
         <dict>
@@ -32,12 +39,41 @@
             <key>Arguments</key>
             <dict>
                 <key>filename</key>
-                <string>%NAME%.dmg</string>
+                <string>%NAME%.zip</string>
+                <key>request_headers</key>
+                <dict>
+                    <key>user-agent</key>
+                    <string>%USER_AGENT%</string>
+                </dict>
             </dict>
         </dict>
         <dict>
             <key>Processor</key>
             <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>Unarchiver</string>
+            <key>Arguments</key>
+            <dict>
+                <key>archive_path</key>
+                <string>%pathname%</string>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/downloads/Applications</string>
+                <key>purge_destination</key>
+                <true/>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+            <key>Arguments</key>
+            <dict>
+                <key>input_path</key>
+                <string>%RECIPE_CACHE_DIR%/downloads/Applications/Carbon Copy Cloner.app</string>
+                <key>requirement</key>
+                <string>certificate root = H"611e5b662c593a08ff58d14ae22452d198df6c60" and certificate leaf[subject.O] = "Bombich Software"* and identifier "com.bombich.ccc"</string>
+            </dict>
         </dict>
     </array>
 </dict>

--- a/CarbonCopyCloner/CarbonCopyCloner.install.recipe
+++ b/CarbonCopyCloner/CarbonCopyCloner.install.recipe
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Installs the current release version of CarbonCopyCloner.</string>
+    <key>Identifier</key>
+    <string>com.github.keeleysam.recipes.CarbonCopyCloner.install</string>
+    <key>Input</key>
+    <dict>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>0.4.0</string>
+    <key>ParentRecipe</key>
+    <string>com.github.keeleysam.recipes.pkg.CarbonCopyCloner</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Processor</key>
+            <string>Installer</string>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/CarbonCopyCloner/CarbonCopyCloner.munki.recipe
+++ b/CarbonCopyCloner/CarbonCopyCloner.munki.recipe
@@ -29,7 +29,7 @@
         </dict>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>0.3.1</string>
     <key>ParentRecipe</key>
     <string>com.github.keeleysam.recipes.CarbonCopyCloner.download</string>
     <key>Process</key>

--- a/CarbonCopyCloner/CarbonCopyCloner.pkg.recipe
+++ b/CarbonCopyCloner/CarbonCopyCloner.pkg.recipe
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Downloads the current release version of CarbonCopyCloner and builds a package.</string>
+	<key>Identifier</key>
+	<string>com.github.keeleysam.recipes.pkg.CarbonCopyCloner</string>
+	<key>Input</key>
+	<dict>
+		<key>NAME</key>
+		<string>CarbonCopyCloner</string>
+	</dict>
+	<key>ParentRecipe</key>
+	<string>com.github.keeleysam.recipes.CarbonCopyCloner.download</string>
+	<key>MinimumVersion</key>
+	<string>0.3.1</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Processor</key>
+			<string>PkgRootCreator</string>
+			<key>Arguments</key>
+			<dict>
+				<key>pkgroot</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%</string>
+				<key>pkgdirs</key>
+				<dict>
+					<key>Applications</key>
+					<string>0775</string>
+				</dict>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>Unarchiver</string>
+			<key>Arguments</key>
+			<dict>
+				<key>archive_path</key>
+				<string>%pathname%</string>
+				<key>destination_path</key>
+				<string>%pkgroot%/Applications</string>
+				<key>purge_destination</key>
+				<true/>
+			</dict>
+		</dict>
+		<dict>
+			<key>Comment</key>
+			<string>Get version from the app</string>
+			<key>Processor</key>
+			<string>Versioner</string>
+			<key>Arguments</key>
+			<dict>
+				<key>input_plist_path</key>
+				<string>%pkgroot%/Applications/Carbon Copy Cloner.app/Contents/Info.plist</string>
+				<key>plist_version_key</key>
+				<string>CFBundleShortVersionString</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>PkgCreator</string>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_request</key>
+				<dict>
+					<key>pkgname</key>
+					<string>%NAME%-%version%</string>
+					<key>version</key>
+					<string>%version%</string>
+					<key>id</key>
+					<string>com.bombich.ccc</string>
+					<key>options</key>
+					<string>purge_ds_store</string>
+					<key>chown</key>
+					<array>
+						<dict>
+							<key>path</key>
+							<string>Applications</string>
+							<key>user</key>
+							<string>root</string>
+							<key>group</key>
+							<string>admin</string>
+						</dict>
+					</array>
+				</dict>
+			</dict>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
As 3.4.x seems to be EOL at this point, switching to ccc-4.xml URL with 'native' user agent. Still getting intermittent timeouts when actually downloading, but functional now. Added CertSigVerification, added
install recipe, broke with previous identifier naming convention for pkg since it changes folder to look like a pkg in the Finder otherwise. Bumped recipe min vers accordingly to accommodate CodeSigVerif and installer
Lightly tested, buyer beware! 😜