### PR TITLE
CCC munki fix - to reflect change to zip

### DIFF
--- a/CarbonCopyCloner/CarbonCopyCloner.munki.recipe
+++ b/CarbonCopyCloner/CarbonCopyCloner.munki.recipe
@@ -35,10 +35,34 @@
     <key>Process</key>
     <array>
         <dict>
+            <key>Processor</key>
+            <string>Unarchiver</string>
+            <key>Arguments</key>
+            <dict>
+                <key>archive_path</key>
+                <string>%pathname%</string>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/downloads/Applications</string>
+                <key>purge_destination</key>
+                <false/>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>DmgCreator</string>
+            <key>Arguments</key>
+            <dict>
+                <key>dmg_root</key>
+                <string>%RECIPE_CACHE_DIR%/downloads/Applications/Carbon Copy Cloner.app</string>
+                <key>dmg_path</key>
+                <string>%RECIPE_CACHE_DIR%/downloads/CarbonCopyCloner.dmg</string>
+            </dict>
+        </dict>
+        <dict>
             <key>Arguments</key>
             <dict>
                 <key>pkg_path</key>
-                <string>%pathname%</string>
+                <string>%RECIPE_CACHE_DIR%/downloads/CarbonCopyCloner.dmg</string>
                 <key>repo_subdirectory</key>
                 <string>%MUNKI_REPO_SUBDIR%</string>
             </dict>

--- a/CarbonCopyCloner/CarbonCopyCloner.munki.recipe
+++ b/CarbonCopyCloner/CarbonCopyCloner.munki.recipe
@@ -44,7 +44,7 @@
                 <key>destination_path</key>
                 <string>%RECIPE_CACHE_DIR%/downloads/Applications</string>
                 <key>purge_destination</key>
-                <false/>
+                <true/>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
Didn’t update to take into account CCC is now a zip download, which requires unarchive-dmgCreate-munkiimport dance. Checks out when tested, please verify.