### PR TITLE
Update FileZilla.download.recipe

### DIFF
--- a/FileZilla/FileZilla.download.recipe
+++ b/FileZilla/FileZilla.download.recipe
@@ -7,7 +7,7 @@
     <key>Input</key>
     <dict>
         <key>IDENTIFIER</key>
-        <string>com.github.keeleysam.recipes.FileZilla.download</string>
+        <string>com.github.keeleysam.recipes.download.FileZilla</string>
     </dict>
     <key>Process</key>
     <array>


### PR DESCRIPTION
Change identifier so that Finder does not see file.download as a in-progress download file from Safari. Most other repos follow this standard where its com.github.user.download.APPNAME.
I'd recommend doing the same for all other download recipes you may have.