### PR TITLE
Update SublimeText2.download.recipe

### DIFF
--- a/SublimeText/SublimeText2.download.recipe
+++ b/SublimeText/SublimeText2.download.recipe
@@ -7,7 +7,7 @@
     <key>Input</key>
     <dict>
         <key>IDENTIFIER</key>
-        <string>com.github.keeleysam.recipes.SublimeText.SublimeText2.download</string>
+        <string>com.github.keeleysam.recipes.download.SublimeText.SublimeText2</string>
         <key>NAME</key>
         <string>SublimeText2</string>
         <key>SPARKLE_FEED_URL</key>


### PR DESCRIPTION
Change identifier so that Finder does not see file.download as a in-progress download file from Safari. Most other repos follow this standard where its com.github.user.download.APPNAME.
I'd recommend doing the same for all other download recipes you may have.