### PR TITLE
Split munki recipes into download + munki recipes.

### DIFF
--- a/Flux/Flux.download.recipe
+++ b/Flux/Flux.download.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the current release version of Flux and imports into Munki.</string>
+    <string>Downloads the current release version of Flux.</string>
     <key>Input</key>
     <dict>
         <key>IDENTIFIER</key>

--- a/GoogleTalkPlugin/GoogleTalkPlugin.download.recipe
+++ b/GoogleTalkPlugin/GoogleTalkPlugin.download.recipe
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Identifier</key>
+    <string>com.github.keeleysam.autopkg.download.GoogleTalkPlugin</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>GoogleTalkPlugin</string>
+        <key>DOWNLOAD_URL</key>
+        <string>https://dl.google.com/googletalk/googletalkplugin/GoogleVoiceAndVideoSetup.dmg</string>
+    </dict>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Processor</key>
+            <string>URLDownloader</string>
+            <key>Arguments</key>
+            <dict>
+                <key>url</key>
+                <string>%DOWNLOAD_URL%</string>
+                <key>filename</key>
+                <string>%NAME%.dmg</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+            <key>Arguments</key>
+            <dict/>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/GoogleTalkPlugin/GoogleTalkPlugin.munki.recipe
+++ b/GoogleTalkPlugin/GoogleTalkPlugin.munki.recipe
@@ -2,16 +2,16 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+    <key>Identifier</key>
+    <string>com.github.keeleysam.recipes.GoogleTalkPlugin</string>
+    <key>ParentRecipe</key>
+    <string>com.github.keeleysam.autopkg.download.GoogleTalkPlugin</string>
     <key>Input</key>
     <dict>
-        <key>IDENTIFIER</key>
-        <string>com.github.keeleysam.recipes.GoogleTalkPlugin</string>
         <key>NAME</key>
         <string>GoogleTalkPlugin</string>
         <key>MUNKI_REPO_SUBDIR</key>
         <string>apps/Google/GoogleTalkPlugin</string>
-        <key>DOWNLOAD_URL</key>
-        <string>https://dl.google.com/googletalk/googletalkplugin/GoogleVoiceAndVideoSetup.dmg</string>
         <key>pkginfo</key>
         <dict>
             <key>catalogs</key>
@@ -49,23 +49,6 @@
     </dict>
     <key>Process</key>
     <array>
-        <dict>
-            <key>Processor</key>
-            <string>URLDownloader</string>
-            <key>Arguments</key>
-            <dict>
-                <key>url</key>
-                <string>%DOWNLOAD_URL%</string>
-                <key>filename</key>
-                <string>%NAME%.dmg</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
-            <key>Arguments</key>
-            <dict/>
-        </dict>
         <dict>
             <key>Arguments</key>
             <dict>

--- a/Handbrake/Handbrake.download.recipe
+++ b/Handbrake/Handbrake.download.recipe
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Identifier</key>
+    <string>com.github.keeleysam.autopkg.download.HandBrake</string>
+    <key>Description</key>
+    <string>Downloads the current release version of HandBrake and imports into Munki.</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>HandBrake</string>
+        <key>SPARKLE_FEED_URL</key>
+        <string>http://handbrake.fr/appcast.x86_64.xml</string>
+    </dict>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Processor</key>
+            <string>SparkleUpdateInfoProvider</string>
+            <key>Arguments</key>
+            <dict>
+                <key>appcast_url</key>
+                <string>%SPARKLE_FEED_URL%</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>URLDownloader</string>
+            <key>Arguments</key>
+            <dict>
+                <key>filename</key>
+                <string>%NAME%.dmg</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/Handbrake/Handbrake.download.recipe
+++ b/Handbrake/Handbrake.download.recipe
@@ -5,7 +5,7 @@
     <key>Identifier</key>
     <string>com.github.keeleysam.autopkg.download.HandBrake</string>
     <key>Description</key>
-    <string>Downloads the current release version of HandBrake and imports into Munki.</string>
+    <string>Downloads the current release version of HandBrake.</string>
     <key>Input</key>
     <dict>
         <key>NAME</key>

--- a/Handbrake/Handbrake.munki.recipe
+++ b/Handbrake/Handbrake.munki.recipe
@@ -2,18 +2,18 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+    <key>Identifier</key>
+    <string>com.github.keeleysam.autopkg.munki.HandBrake</string>
+    <key>ParentRecipe</key>
+    <string>com.github.keeleysam.autopkg.download.HandBrake</string>
     <key>Description</key>
     <string>Downloads the current release version of HandBrake and imports into Munki.</string>
     <key>Input</key>
     <dict>
-        <key>IDENTIFIER</key>
-        <string>com.github.keeleysam.autopkg.munki.HandBrake</string>
         <key>NAME</key>
         <string>HandBrake</string>
         <key>MUNKI_REPO_SUBDIR</key>
         <string>apps/HandBrake</string>
-        <key>SPARKLE_FEED_URL</key>
-        <string>http://handbrake.fr/appcast.x86_64.xml</string>
         <key>pkginfo</key>
         <dict>
             <key>catalogs</key>
@@ -32,28 +32,6 @@
     </dict>
     <key>Process</key>
     <array>
-        <dict>
-            <key>Processor</key>
-            <string>SparkleUpdateInfoProvider</string>
-            <key>Arguments</key>
-            <dict>
-                <key>appcast_url</key>
-                <string>%SPARKLE_FEED_URL%</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>URLDownloader</string>
-            <key>Arguments</key>
-            <dict>
-                <key>filename</key>
-                <string>%NAME%.dmg</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
-        </dict>
         <dict>
             <key>Arguments</key>
             <dict>

--- a/Panic/Coda.download.recipe
+++ b/Panic/Coda.download.recipe
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Identifier</key>
+    <string>com.github.keeleysam.autopkg.download.Coda</string>
+    <key>Description</key>
+    <string>Downloads the current release version of Coda and imports into Munki.</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>Coda</string>
+        <key>SPARKLE_FEED_URL</key>
+        <string>http://www.panic.com/updates/coda/coda-en.xml</string>
+    </dict>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Processor</key>
+            <string>SparkleUpdateInfoProvider</string>
+            <key>Arguments</key>
+            <dict>
+                <key>appcast_url</key>
+                <string>%SPARKLE_FEED_URL%</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>URLDownloader</string>
+            <key>Arguments</key>
+            <dict>
+                <key>filename</key>
+                <string>%NAME%.zip</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/Panic/Coda.download.recipe
+++ b/Panic/Coda.download.recipe
@@ -5,7 +5,7 @@
     <key>Identifier</key>
     <string>com.github.keeleysam.autopkg.download.Coda</string>
     <key>Description</key>
-    <string>Downloads the current release version of Coda and imports into Munki.</string>
+    <string>Downloads the current release version of Coda.</string>
     <key>Input</key>
     <dict>
         <key>NAME</key>

--- a/Panic/Coda.munki.recipe
+++ b/Panic/Coda.munki.recipe
@@ -2,18 +2,18 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+    <key>Identifier</key>
+    <string>com.github.keeleysam.autopkg.munki.Coda</string>
+    <key>ParentRecipe</key>
+    <string>com.github.keeleysam.autopkg.download.Coda</string>
     <key>Description</key>
     <string>Downloads the current release version of Coda and imports into Munki.</string>
     <key>Input</key>
     <dict>
-        <key>IDENTIFIER</key>
-        <string>com.github.keeleysam.autopkg.munki.Coda</string>
         <key>NAME</key>
         <string>Coda</string>
         <key>MUNKI_REPO_SUBDIR</key>
         <string>apps/Panic/Coda</string>
-        <key>SPARKLE_FEED_URL</key>
-        <string>http://www.panic.com/updates/coda/coda-en.xml</string>
         <key>pkginfo</key>
         <dict>
             <key>catalogs</key>
@@ -32,28 +32,6 @@
     </dict>
     <key>Process</key>
     <array>
-        <dict>
-            <key>Processor</key>
-            <string>SparkleUpdateInfoProvider</string>
-            <key>Arguments</key>
-            <dict>
-                <key>appcast_url</key>
-                <string>%SPARKLE_FEED_URL%</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>URLDownloader</string>
-            <key>Arguments</key>
-            <dict>
-                <key>filename</key>
-                <string>%NAME%.zip</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
-        </dict>
         <dict>
             <key>Processor</key>
             <string>Unarchiver</string>

--- a/Panic/Coda2.download.recipe
+++ b/Panic/Coda2.download.recipe
@@ -5,7 +5,7 @@
     <key>Identifier</key>
     <string>com.github.keeleysam.autopkg.download.Coda2</string>
     <key>Description</key>
-    <string>Downloads the current release version of Coda 2 and imports into Munki.</string>
+    <string>Downloads the current release version of Coda 2.</string>
     <key>Input</key>
     <dict>
         <key>NAME</key>

--- a/Panic/Coda2.download.recipe
+++ b/Panic/Coda2.download.recipe
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Identifier</key>
+    <string>com.github.keeleysam.autopkg.download.Coda2</string>
+    <key>Description</key>
+    <string>Downloads the current release version of Coda 2 and imports into Munki.</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>Coda2</string>
+        <key>SPARKLE_FEED_URL</key>
+        <string>http://www.panic.com/updates/update.php?appName=Coda%202</string>
+    </dict>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Processor</key>
+            <string>SparkleUpdateInfoProvider</string>
+            <key>Arguments</key>
+            <dict>
+                <key>appcast_url</key>
+                <string>%SPARKLE_FEED_URL%</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>URLDownloader</string>
+            <key>Arguments</key>
+            <dict>
+                <key>filename</key>
+                <string>%NAME%.zip</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/Panic/Coda2.munki.recipe
+++ b/Panic/Coda2.munki.recipe
@@ -2,18 +2,18 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+    <key>Identifier</key>
+    <string>com.github.keeleysam.autopkg.munki.Coda2</string>
+    <key>ParentRecipe</key>
+    <string>com.github.keeleysam.autopkg.download.Coda2</string>
     <key>Description</key>
     <string>Downloads the current release version of Coda 2 and imports into Munki.</string>
     <key>Input</key>
     <dict>
-        <key>IDENTIFIER</key>
-        <string>com.github.keeleysam.autopkg.munki.Coda2</string>
         <key>NAME</key>
         <string>Coda2</string>
         <key>MUNKI_REPO_SUBDIR</key>
         <string>apps/Panic/Coda2</string>
-        <key>SPARKLE_FEED_URL</key>
-        <string>http://www.panic.com/updates/update.php?appName=Coda%202</string>
         <key>pkginfo</key>
         <dict>
             <key>catalogs</key>
@@ -32,28 +32,6 @@
     </dict>
     <key>Process</key>
     <array>
-        <dict>
-            <key>Processor</key>
-            <string>SparkleUpdateInfoProvider</string>
-            <key>Arguments</key>
-            <dict>
-                <key>appcast_url</key>
-                <string>%SPARKLE_FEED_URL%</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>URLDownloader</string>
-            <key>Arguments</key>
-            <dict>
-                <key>filename</key>
-                <string>%NAME%.zip</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
-        </dict>
         <dict>
             <key>Processor</key>
             <string>Unarchiver</string>

--- a/Panic/Transmit.download.recipe
+++ b/Panic/Transmit.download.recipe
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Identifier</key>
+    <string>com.github.keeleysam.autopkg.download.Transmit</string>
+    <key>Description</key>
+    <string>Downloads the current release version of Transmit and imports into Munki.</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>Transmit</string>
+        <key>SPARKLE_FEED_URL</key>
+        <string>http://www.panic.com/updates/transmit/transmit-en.xml</string>
+    </dict>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Processor</key>
+            <string>SparkleUpdateInfoProvider</string>
+            <key>Arguments</key>
+            <dict>
+                <key>appcast_url</key>
+                <string>%SPARKLE_FEED_URL%</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>URLDownloader</string>
+            <key>Arguments</key>
+            <dict>
+                <key>filename</key>
+                <string>%NAME%.zip</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/Panic/Transmit.download.recipe
+++ b/Panic/Transmit.download.recipe
@@ -5,7 +5,7 @@
     <key>Identifier</key>
     <string>com.github.keeleysam.autopkg.download.Transmit</string>
     <key>Description</key>
-    <string>Downloads the current release version of Transmit and imports into Munki.</string>
+    <string>Downloads the current release version of Transmit.</string>
     <key>Input</key>
     <dict>
         <key>NAME</key>

--- a/Panic/Transmit.munki.recipe
+++ b/Panic/Transmit.munki.recipe
@@ -2,18 +2,18 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+    <key>Identifier</key>
+    <string>com.github.keeleysam.autopkg.munki.Transmit</string>
+    <key>ParentRecipe</key>
+    <string>com.github.keeleysam.autopkg.download.Transmit</string>
     <key>Description</key>
     <string>Downloads the current release version of Transmit and imports into Munki.</string>
     <key>Input</key>
     <dict>
-        <key>IDENTIFIER</key>
-        <string>com.github.keeleysam.autopkg.munki.Transmit</string>
         <key>NAME</key>
         <string>Transmit</string>
         <key>MUNKI_REPO_SUBDIR</key>
         <string>apps/Panic/Transmit</string>
-        <key>SPARKLE_FEED_URL</key>
-        <string>http://www.panic.com/updates/transmit/transmit-en.xml</string>
         <key>pkginfo</key>
         <dict>
             <key>catalogs</key>
@@ -32,28 +32,6 @@
     </dict>
     <key>Process</key>
     <array>
-        <dict>
-            <key>Processor</key>
-            <string>SparkleUpdateInfoProvider</string>
-            <key>Arguments</key>
-            <dict>
-                <key>appcast_url</key>
-                <string>%SPARKLE_FEED_URL%</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>URLDownloader</string>
-            <key>Arguments</key>
-            <dict>
-                <key>filename</key>
-                <string>%NAME%.zip</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
-        </dict>
         <dict>
             <key>Processor</key>
             <string>Unarchiver</string>

--- a/Panic/Unison.download.recipe
+++ b/Panic/Unison.download.recipe
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Identifier</key>
+    <string>com.github.keeleysam.autopkg.download.Unison</string>
+    <key>Description</key>
+    <string>Downloads the current release version of Unison and imports into Munki.</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>Unison</string>
+        <key>SPARKLE_FEED_URL</key>
+        <string>http://www.panic.com/updates/unison/unison-en.xml</string>
+    </dict>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Processor</key>
+            <string>SparkleUpdateInfoProvider</string>
+            <key>Arguments</key>
+            <dict>
+                <key>appcast_url</key>
+                <string>%SPARKLE_FEED_URL%</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>URLDownloader</string>
+            <key>Arguments</key>
+            <dict>
+                <key>filename</key>
+                <string>%NAME%.zip</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/Panic/Unison.download.recipe
+++ b/Panic/Unison.download.recipe
@@ -5,7 +5,7 @@
     <key>Identifier</key>
     <string>com.github.keeleysam.autopkg.download.Unison</string>
     <key>Description</key>
-    <string>Downloads the current release version of Unison and imports into Munki.</string>
+    <string>Downloads the current release version of Unison.</string>
     <key>Input</key>
     <dict>
         <key>NAME</key>

--- a/Panic/Unison.munki.recipe
+++ b/Panic/Unison.munki.recipe
@@ -2,18 +2,18 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+    <key>Identifier</key>
+    <string>com.github.keeleysam.autopkg.munki.Unison</string>
+    <key>ParentRecipe</key>
+    <string>com.github.keeleysam.autopkg.download.Unison</string>
     <key>Description</key>
     <string>Downloads the current release version of Unison and imports into Munki.</string>
     <key>Input</key>
     <dict>
-        <key>IDENTIFIER</key>
-        <string>com.github.keeleysam.autopkg.munki.Unison</string>
         <key>NAME</key>
         <string>Unison</string>
         <key>MUNKI_REPO_SUBDIR</key>
         <string>apps/Panic/Unison</string>
-        <key>SPARKLE_FEED_URL</key>
-        <string>http://www.panic.com/updates/unison/unison-en.xml</string>
         <key>pkginfo</key>
         <dict>
             <key>catalogs</key>
@@ -32,28 +32,6 @@
     </dict>
     <key>Process</key>
     <array>
-        <dict>
-            <key>Processor</key>
-            <string>SparkleUpdateInfoProvider</string>
-            <key>Arguments</key>
-            <dict>
-                <key>appcast_url</key>
-                <string>%SPARKLE_FEED_URL%</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>URLDownloader</string>
-            <key>Arguments</key>
-            <dict>
-                <key>filename</key>
-                <string>%NAME%.zip</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
-        </dict>
         <dict>
             <key>Processor</key>
             <string>Unarchiver</string>

--- a/PrimateLabs/Geekbench2.download.recipe
+++ b/PrimateLabs/Geekbench2.download.recipe
@@ -5,7 +5,7 @@
     <key>Identifier</key>
     <string>com.github.keeleysam.autopkg.download.Geekbench2</string>
     <key>Description</key>
-    <string>Downloads the current release version of Geekbench 2 and imports into Munki.</string>
+    <string>Downloads the current release version of Geekbench 2.</string>
     <key>Input</key>
     <dict>
         <key>NAME</key>

--- a/PrimateLabs/Geekbench2.download.recipe
+++ b/PrimateLabs/Geekbench2.download.recipe
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Identifier</key>
+    <string>com.github.keeleysam.autopkg.download.Geekbench2</string>
+    <key>Description</key>
+    <string>Downloads the current release version of Geekbench 2 and imports into Munki.</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>Geekbench2</string>
+        <key>SPARKLE_FEED_URL</key>
+        <string>http://www.primatelabs.com/appcast/geekbench2.xml</string>
+    </dict>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Processor</key>
+            <string>SparkleUpdateInfoProvider</string>
+            <key>Arguments</key>
+            <dict>
+                <key>appcast_url</key>
+                <string>%SPARKLE_FEED_URL%</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>URLDownloader</string>
+            <key>Arguments</key>
+            <dict>
+                <key>filename</key>
+                <string>%NAME%.zip</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/PrimateLabs/Geekbench2.munki.recipe
+++ b/PrimateLabs/Geekbench2.munki.recipe
@@ -2,18 +2,18 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+    <key>Identifier</key>
+    <string>com.github.keeleysam.recipes.primatelabs.Geekbench2.munki</string>
+    <key>ParentRecipe</key>
+    <string>com.github.keeleysam.autopkg.download.Geekbench2</string>
     <key>Description</key>
     <string>Downloads the current release version of Geekbench 2 and imports into Munki.</string>
     <key>Input</key>
     <dict>
-        <key>IDENTIFIER</key>
-        <string>com.github.keeleysam.recipes.primatelabs.Geekbench2.munki</string>
         <key>NAME</key>
         <string>Geekbench2</string>
         <key>MUNKI_REPO_SUBDIR</key>
         <string>apps/PrimateLabs/Geekbench2</string>
-        <key>SPARKLE_FEED_URL</key>
-        <string>http://www.primatelabs.com/appcast/geekbench2.xml</string>
         <key>pkginfo</key>
         <dict>
             <key>catalogs</key>
@@ -32,28 +32,6 @@
     </dict>
     <key>Process</key>
     <array>
-        <dict>
-            <key>Processor</key>
-            <string>SparkleUpdateInfoProvider</string>
-            <key>Arguments</key>
-            <dict>
-                <key>appcast_url</key>
-                <string>%SPARKLE_FEED_URL%</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>URLDownloader</string>
-            <key>Arguments</key>
-            <dict>
-                <key>filename</key>
-                <string>%NAME%.zip</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
-        </dict>
         <dict>
             <key>Processor</key>
             <string>Unarchiver</string>

--- a/PrimateLabs/Wiinote.download.recipe
+++ b/PrimateLabs/Wiinote.download.recipe
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Identifier</key>
+    <string>com.github.keeleysam.autopkg.download.Wiinote</string>
+    <key>Description</key>
+    <string>Downloads the current release version of Wiinote and imports into Munki.</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>Wiinote</string>
+        <key>SPARKLE_FEED_URL</key>
+        <string>http://www.primatelabs.com/appcast/wiinote.xml</string>
+    </dict>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Processor</key>
+            <string>SparkleUpdateInfoProvider</string>
+            <key>Arguments</key>
+            <dict>
+                <key>appcast_url</key>
+                <string>%SPARKLE_FEED_URL%</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>URLDownloader</string>
+            <key>Arguments</key>
+            <dict>
+                <key>filename</key>
+                <string>%NAME%.zip</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/PrimateLabs/Wiinote.download.recipe
+++ b/PrimateLabs/Wiinote.download.recipe
@@ -5,7 +5,7 @@
     <key>Identifier</key>
     <string>com.github.keeleysam.autopkg.download.Wiinote</string>
     <key>Description</key>
-    <string>Downloads the current release version of Wiinote and imports into Munki.</string>
+    <string>Downloads the current release version of Wiinote.</string>
     <key>Input</key>
     <dict>
         <key>NAME</key>

--- a/PrimateLabs/Wiinote.munki.recipe
+++ b/PrimateLabs/Wiinote.munki.recipe
@@ -2,18 +2,18 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+    <key>Identifier</key>
+    <string>com.github.keeleysam.recipes.primatelabs.Wiinote.munki</string>
+    <key>ParentRecipe</key>
+    <string>com.github.keeleysam.autopkg.download.Wiinote</string>
     <key>Description</key>
     <string>Downloads the current release version of Wiinote and imports into Munki.</string>
     <key>Input</key>
     <dict>
-        <key>IDENTIFIER</key>
-        <string>com.github.keeleysam.recipes.primatelabs.Wiinote.munki</string>
         <key>NAME</key>
         <string>Wiinote</string>
         <key>MUNKI_REPO_SUBDIR</key>
         <string>apps/PrimateLabs/Wiinote</string>
-        <key>SPARKLE_FEED_URL</key>
-        <string>http://www.primatelabs.com/appcast/wiinote.xml</string>
         <key>pkginfo</key>
         <dict>
             <key>catalogs</key>
@@ -32,28 +32,6 @@
     </dict>
     <key>Process</key>
     <array>
-        <dict>
-            <key>Processor</key>
-            <string>SparkleUpdateInfoProvider</string>
-            <key>Arguments</key>
-            <dict>
-                <key>appcast_url</key>
-                <string>%SPARKLE_FEED_URL%</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>URLDownloader</string>
-            <key>Arguments</key>
-            <dict>
-                <key>filename</key>
-                <string>%NAME%.zip</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
-        </dict>
         <dict>
             <key>Processor</key>
             <string>Unarchiver</string>

--- a/gfxCardStatus/gfxCardStatus.download.recipe
+++ b/gfxCardStatus/gfxCardStatus.download.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the current release version of gfxCardStatus and imports into Munki.</string>
+    <string>Downloads the current release version of gfxCardStatus.</string>
     <key>Input</key>
     <dict>
         <key>IDENTIFIER</key>

--- a/iTerm2/iTerm2.download.recipe
+++ b/iTerm2/iTerm2.download.recipe
@@ -5,7 +5,7 @@
     <key>Identifier</key>
     <string>com.github.keeleysam.autopkg.download.iTerm2</string>
     <key>Description</key>
-    <string>Downloads the current release version of iTerm 2 and imports into Munki.</string>
+    <string>Downloads the current release version of iTerm 2.</string>
     <key>Input</key>
     <dict>
         <key>NAME</key>

--- a/iTerm2/iTerm2.download.recipe
+++ b/iTerm2/iTerm2.download.recipe
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Identifier</key>
+    <string>com.github.keeleysam.autopkg.download.iTerm2</string>
+    <key>Description</key>
+    <string>Downloads the current release version of iTerm 2 and imports into Munki.</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>iTerm2</string>
+        <key>SPARKLE_FEED_URL</key>
+        <string>http://iterm2.googlecode.com/svn/trunk/appcasts/final.xml</string>
+    </dict>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Processor</key>
+            <string>SparkleUpdateInfoProvider</string>
+            <key>Arguments</key>
+            <dict>
+                <key>appcast_url</key>
+                <string>%SPARKLE_FEED_URL%</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>URLDownloader</string>
+            <key>Arguments</key>
+            <dict>
+                <key>filename</key>
+                <string>%NAME%.zip</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/iTerm2/iTerm2.munki.recipe
+++ b/iTerm2/iTerm2.munki.recipe
@@ -2,18 +2,18 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+    <key>Identifier</key>
+    <string>com.github.keeleysam.autopkg.munki.iTerm2</string>
+    <key>ParentRecipe</key>
+    <string>com.github.keeleysam.autopkg.download.iTerm2</string>
     <key>Description</key>
     <string>Downloads the current release version of iTerm 2 and imports into Munki.</string>
     <key>Input</key>
     <dict>
-        <key>IDENTIFIER</key>
-        <string>com.github.keeleysam.autopkg.munki.iTerm2</string>
         <key>NAME</key>
         <string>iTerm2</string>
         <key>MUNKI_REPO_SUBDIR</key>
         <string>apps/iTerm2</string>
-        <key>SPARKLE_FEED_URL</key>
-        <string>http://iterm2.googlecode.com/svn/trunk/appcasts/final.xml</string>
         <key>pkginfo</key>
         <dict>
             <key>catalogs</key>
@@ -32,28 +32,6 @@
     </dict>
     <key>Process</key>
     <array>
-        <dict>
-            <key>Processor</key>
-            <string>SparkleUpdateInfoProvider</string>
-            <key>Arguments</key>
-            <dict>
-                <key>appcast_url</key>
-                <string>%SPARKLE_FEED_URL%</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>URLDownloader</string>
-            <key>Arguments</key>
-            <dict>
-                <key>filename</key>
-                <string>%NAME%.zip</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
-        </dict>
         <dict>
             <key>Processor</key>
             <string>Unarchiver</string>


### PR DESCRIPTION
For new identifiers, used Sam's standard `com.github.keeleysam.autopkg.download.NAME` format.

Fixes #49.