### PR TITLE
Use HTTPS to fetch Bartender

### DIFF
--- a/SurteesStudios/Bartender.download.recipe
+++ b/SurteesStudios/Bartender.download.recipe
@@ -11,7 +11,7 @@
 		<key>NAME</key>
 		<string>Bartender</string>
 		<key>SPARKLE_FEED_URL</key>
-		<string>http://www.macbartender.com/updates/Appcast.xml</string>
+		<string>https://www.macbartender.com/updates/Appcast.xml</string>
 		<key>USER_AGENT</key>
 		<string>Mozilla/5.0</string>
 	</dict>


### PR DESCRIPTION
The sparkle feed for Bartender is now served over HTTPS, and plain requests receive HTTP 302. AutoPkg doesn't deal with this gracefully so instead the recipe fails. A tiny change to SPARKLE_FEED_URL should sort that out!