### PR TITLE
CHECK_FILESIZE_ONLY and Filename

### DIFF
--- a/FileZilla/FileZilla.download.recipe
+++ b/FileZilla/FileZilla.download.recipe
@@ -25,6 +25,14 @@
 		<dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>
+			<key>Arguments</key>
+              		<dict>
+            			<!-- Due to the use of mirrors, the ETag and Modified Dates cannot be used -->
+          			<key>CHECK_FILESIZE_ONLY</key>
+          			<true/>
+                                <key>filename</key>
+				<string>%NAME%.tar.bz2</string>
+              		</dict>
 		</dict>
 		<dict>
 			<key>Processor</key>


### PR DESCRIPTION
Due to the use of sourceforge mirrors, the ETag and Modified Dates cannot be used.
Added Filename to have Unarchiver choosing the last downloaded file.