### PR TITLE
Change FileZilla munki parent recipe

### DIFF
--- a/FileZilla/FileZilla.munki.recipe
+++ b/FileZilla/FileZilla.munki.recipe
@@ -31,7 +31,7 @@
 	<key>MinimumVersion</key>
 	<string>0.2.0</string>
 	<key>ParentRecipe</key>
-	<string>com.github.keeleysam.recipes.FileZilla.download</string>
+	<string>com.github.hansen-m.download.FileZilla</string>
 	<key>Process</key>
 	<array>
 		<dict>


### PR DESCRIPTION
Since the download recipe is 404'ing, there seems to be another working download recipe that can act as a parent recipe.