### PR TITLE
Added CodeSignatureVerifier to the .app bundle for Opera

### DIFF
--- a/Opera/Opera.download.recipe
+++ b/Opera/Opera.download.recipe
@@ -32,6 +32,17 @@
 		</dict>
 		<dict>
 			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
+			<key>Arguments</key>
+			<dict>
+				<key>input_path</key>
+				<string>%RECIPE_CACHE_DIR%/downloads/%NAME%.dmg/Opera.app</string>
+				<key>requirement</key>
+				<string>identifier "com.operasoftware.Opera" and certificate leaf = H"261cd515406974afa19778f62e5d916ec977ebf4"</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
 			<string>EndOfCheckPhase</string>
 		</dict>
 	</array>


### PR DESCRIPTION
Hi @keeleysam 

I've tweaked your Opera .download recipe to include a CodeSignatureVerifier process for the .app bundle, I hope you don't mind?

Thanks!

Darren