### PR TITLE
Add Unarchiver Processor to fix glob error

### DIFF
--- a/FileZilla/FileZilla.download.recipe
+++ b/FileZilla/FileZilla.download.recipe
@@ -34,6 +34,15 @@
 			<string>URLDownloader</string>
 		</dict>
 		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/downloads</string>
+			</dict>
+			<key>Processor</key>
+			<string>Unarchiver</string>
+		</dict>
+		<dict>
 			<key>Processor</key>
 			<string>EndOfCheckPhase</string>
 		</dict>


### PR DESCRIPTION
Add Unarchiver Processor to fix glob error for recent CodeSignatureVerifier commit. (https://github.com/autopkg/keeleysam-recipes/commit/f8fe7b03b274cfff75c17f274b0824ef5556b05b)

```
CodeSignatureVerifier
{'Input': {'input_path': u'/Users/ladmin/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.download/downloads/FileZilla.app',
           'requirement': u'identifier "org.filezilla-project.filezilla" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "5VPGKXL75N"'}}
Error processing path '/Users/ladmin/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.download/downloads/FileZilla.app' with glob. 
Failed.
```
The munki recipe should probably be cleaned up too as that uses Unarchiver Processor and will result in redundant and unnecessary files with different paths.