### PR TITLE
Fixed code signature verification

### DIFF
--- a/FileZilla/FileZilla.download.recipe
+++ b/FileZilla/FileZilla.download.recipe
@@ -39,11 +39,15 @@
 		</dict>
 		<dict>
 			<key>Processor</key>
+			<string>Unarchiver</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/downloads/FileZilla.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/FileZilla.app</string>
 				<key>requirement</key>
 				<string>identifier "org.filezilla-project.filezilla" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "5VPGKXL75N"</string>
 			</dict>


### PR DESCRIPTION
CodeSignatureVerifier processor can do a .dmg but not a .tar.gz. Needs to be unarchived first.