### PR TITLE
Added Unarchiver processor changed CodeSignatureVerifier input_path

### DIFF
--- a/FileZilla/FileZilla.download.recipe
+++ b/FileZilla/FileZilla.download.recipe
@@ -38,12 +38,25 @@
 			<string>EndOfCheckPhase</string>
 		</dict>
 		<dict>
+                        <key>Arguments</key>
+                        <dict>
+                                <key>archive_path</key>
+                                <string>%pathname%</string>
+                                <key>destination_path</key>
+                                <string>%RECIPE_CACHE_DIR%/%NAME%</string>
+                                <key>purge_destination</key>
+                                <true/>
+                        </dict>
+                        <key>Processor</key>
+                        <string>Unarchiver</string>
+                </dict>
+		<dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/downloads/FileZilla.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
 				<key>requirement</key>
 				<string>identifier "org.filezilla-project.filezilla" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "5VPGKXL75N"</string>
 			</dict>


### PR DESCRIPTION
Added Unarchiver processor because of tar.bz2 file and changed the CodeSignatureVerifier input_path to meet the download location of the unarchived file.