### PR TITLE
Fixes URL for download

### DIFF
--- a/FileZilla/FileZilla.download.recipe
+++ b/FileZilla/FileZilla.download.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the current version of FileZilla. Specify the channel via %NAME%.</string>
+	<string>Downloads the current version of FileZilla.</string>
 	<key>Identifier</key>
 	<string>com.github.keeleysam.recipes.FileZilla.download</string>
 	<key>Input</key>
@@ -16,19 +16,8 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>product_name</key>
-				<string>%NAME%</string>
-			</dict>
-			<key>Processor</key>
-			<string>FileZillaURLProvider</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>CHECK_FILESIZE_ONLY</key>
-				<true/>
-				<key>filename</key>
-				<string>%NAME%.tar.bz2</string>
+				<key>url</key>
+				<string>https://download.filezilla-project.org//client/FileZilla_latest_macosx-x86.app.tar.bz2</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>


### PR DESCRIPTION
The FileZilla URL provider no longer works to provide a valid tarball.