### PR TITLE
[Opera] Update download url and code signature

### DIFF
--- a/Opera/Opera.download.recipe
+++ b/Opera/Opera.download.recipe
@@ -38,7 +38,7 @@
 				<key>input_path</key>
 				<string>%RECIPE_CACHE_DIR%/downloads/%NAME%.dmg/Opera.app</string>
 				<key>requirement</key>
-				<string>identifier "com.operasoftware.Opera" and certificate leaf = H"261cd515406974afa19778f62e5d916ec977ebf4"</string>
+				<string>(identifier "com.operasoftware.Opera" or identifier "com.operasoftware.OperaNext" or identifier "com.operasoftware.OperaDeveloper" or identifier "com.operasoftware.OperaNightly") and (certificate leaf = H"cdf1c39967986616b6cd64c6bd04833a9cb7450d" or certificate leaf = H"261cd515406974afa19778f62e5d916ec977ebf4")</string>
 			</dict>
 		</dict>
 		<dict>

--- a/Opera/OperaURLProvider.py
+++ b/Opera/OperaURLProvider.py
@@ -23,7 +23,7 @@ from autopkglib import Processor
 __all__ = ["OperaURLProvider"]
 
 
-BASE_URL = "http://get.geo.opera.com/ftp/pub/opera/desktop/desktop/"
+BASE_URL = "http://get.geo.opera.com/ftp/pub/opera/desktop/"
 
 
 class OperaURLProvider(Processor):


### PR DESCRIPTION
Their download URL changed and there's only one `desktop` folder now. Code signature changed too.

```
$ autopkg run ./Opera.munki.recipe -v                                                  
Processing ./Opera.munki.recipe...
WARNING: ./Opera.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
OperaURLProvider
OperaURLProvider: Found URL http://get.geo.opera.com/ftp/pub/opera/desktop/56.0.3051.31/mac/Opera_56.0.3051.31_Setup.dmg
URLDownloader
URLDownloader: Storing new Last-Modified header: Tue, 25 Sep 2018 12:05:09 GMT
URLDownloader: Downloaded /Users/cwhits/Library/AutoPkg/Cache/com.github.keeleysam.recipes.Opera.munki/downloads/Opera.dmg
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/cwhits/Library/AutoPkg/Cache/com.github.keeleysam.recipes.Opera.munki/downloads/Opera.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.A8Juf3/Opera.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.A8Juf3/Opera.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.A8Juf3/Opera.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
EndOfCheckPhase
MunkiImporter
MunkiImporter: Copied pkginfo to /munki/pkgsinfo/apps/Opera/Opera-56.0.plist
MunkiImporter: Copied pkg to /munki/pkgs/apps/Opera/Opera-56.0.dmg
Receipt written to /Users/cwhits/Library/AutoPkg/Cache/com.github.keeleysam.recipes.Opera.munki/receipts/Opera.munki-receipt-20180928-084830.plist

The following new items were imported into Munki:
    Name   Version  Catalogs  Pkginfo Path                    Pkg Repo Path                 
    ----   -------  --------  ------------                    -------------                 
    Opera  56.0     testing   apps/Opera/Opera-56.0.plist  apps/Opera/Opera-56.0.dmg  

The following new items were downloaded:
    Download Path                                                                                     
    -------------                                                                                     
    /Users/cwhits/Library/AutoPkg/Cache/com.github.keeleysam.recipes.Opera.munki/downloads/Opera.dmg 
```