### PR TITLE
Add user-agent for Filezilla download - Fix #93

### DIFF
--- a/FileZilla/FileZilla.download.recipe
+++ b/FileZilla/FileZilla.download.recipe
@@ -29,6 +29,11 @@
 				<true/>
 				<key>filename</key>
 				<string>%NAME%.tar.bz2</string>
+				<key>request_headers</key>
+				<dict>
+					<key>user-agent</key>
+					<string>FileZilla 3.25.1</string>
+				</dict>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>


### PR DESCRIPTION
The Filezilla download server provided by the Filezilla update service requires `FileZilla` as a `user-agent`. Without the required `user-agent` the download server redirects the download to https://filezilla-project.org/