### PR TITLE
Basic python3 compatibility

### DIFF
--- a/CarbonCopyCloner/CarbonCopyClonerURLProvider.py
+++ b/CarbonCopyCloner/CarbonCopyClonerURLProvider.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import urllib2
 
 from autopkglib import Processor
-
 
 __all__ = ["CarbonCopyClonerURLProvider"]
 

--- a/CarbonCopyCloner/CarbonCopyClonerURLProvider.py
+++ b/CarbonCopyCloner/CarbonCopyClonerURLProvider.py
@@ -44,7 +44,7 @@ class CarbonCopyClonerURLProvider(Processor):
             opener = urllib2.build_opener(urllib2.HTTPRedirectHandler)
             request = opener.open(url)
             return request.url
-        except BaseException as err:
+        except Exception as err:
             raise Exception("Can't read %s: %s" % (url, err))
 
     def main(self):

--- a/CarbonCopyCloner/CarbonCopyClonerURLProvider.py
+++ b/CarbonCopyCloner/CarbonCopyClonerURLProvider.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import urllib2
 
 from autopkglib import Processor

--- a/FileZilla/FileZillaURLProvider.py
+++ b/FileZilla/FileZillaURLProvider.py
@@ -16,12 +16,15 @@
 # limitations under the License.
 
 from __future__ import absolute_import
-import urllib2
-import re
 import ssl
 ssl._create_default_https_context = ssl._create_unverified_context
 
 from autopkglib import Processor, ProcessorError
+
+try:
+    from urllib.request import urlopen  # For Python 3
+except ImportError:
+    from urllib2 import urlopen  # For Python 2
 
 __all__ = ["FileZillaURLProvider"]
 
@@ -62,7 +65,7 @@ class FileZillaURLProvider(Processor):
                 (prod, ', '.join(prods)))
 
         try:
-            manifest_str = urllib2.urlopen(update_url).read()
+            manifest_str = urlopen(update_url).read()
             # print(manifest_str)
         except BaseException as e:
             raise ProcessorError(

--- a/FileZilla/FileZillaURLProvider.py
+++ b/FileZilla/FileZillaURLProvider.py
@@ -70,7 +70,7 @@ class FileZillaURLProvider(Processor):
         try:
             manifest_str = urlopen(update_url).read()
             # print(manifest_str)
-        except BaseException as e:
+        except Exception as e:
             raise ProcessorError(
                 "Unexpected error retrieving product manifest: '%s'" %
                 e)

--- a/FileZilla/FileZillaURLProvider.py
+++ b/FileZilla/FileZillaURLProvider.py
@@ -63,7 +63,7 @@ class FileZillaURLProvider(Processor):
 
         try:
             manifest_str = urllib2.urlopen(update_url).read()
-            # print manifest_str
+            # print(manifest_str)
         except BaseException as e:
             raise ProcessorError(
                 "Unexpected error retrieving product manifest: '%s'" %

--- a/FileZilla/FileZillaURLProvider.py
+++ b/FileZilla/FileZillaURLProvider.py
@@ -16,10 +16,13 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import ssl
-ssl._create_default_https_context = ssl._create_unverified_context
 
 from autopkglib import Processor, ProcessorError
+
+ssl._create_default_https_context = ssl._create_unverified_context
+
 
 try:
     from urllib.request import urlopen  # For Python 3

--- a/FileZilla/FileZillaURLProvider.py
+++ b/FileZilla/FileZillaURLProvider.py
@@ -39,7 +39,7 @@ class FileZillaURLProvider(Processor):
     input_variables = {
         "product_name": {
             "required": True,
-            "description": "Product to fetch URL for. One of 'FileZilla', 'FileZilla_release', 'FileZilla_beta', 'FileZilla_nightly'.",
+            "description": "Product to fetch URL for. One of: %s" % ', '.join(prods),
         },
     }
     output_variables = {
@@ -55,12 +55,11 @@ class FileZillaURLProvider(Processor):
 
     def main(self):
 
-        valid_prods = prods.keys()
         prod = self.env.get("product_name").lower()
-        if prod not in valid_prods:
+        if prod not in prods:
             raise ProcessorError(
                 "product_name %s is invalid; it must be one of: %s" %
-                (prod, valid_prods))
+                (prod, ', '.join(prods)))
 
         try:
             manifest_str = urllib2.urlopen(update_url).read()

--- a/FileZilla/FileZillaURLProvider.py
+++ b/FileZilla/FileZillaURLProvider.py
@@ -15,6 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import urllib2
 import re
 import ssl

--- a/GoogleTalkPlugin/MunkiPkginfoReceiptsEditor.py
+++ b/GoogleTalkPlugin/MunkiPkginfoReceiptsEditor.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
 from FoundationPlist import readPlist, writePlist
 from autopkglib import Processor, ProcessorError
 

--- a/GoogleTalkPlugin/MunkiPkginfoReceiptsEditor.py
+++ b/GoogleTalkPlugin/MunkiPkginfoReceiptsEditor.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 
 from __future__ import absolute_import
-from FoundationPlist import readPlist, writePlist
+
 from autopkglib import Processor, ProcessorError
+from FoundationPlist import readPlist, writePlist
 
 __all__ = ["MunkiPkginfoReceiptsEditor"]
 

--- a/Opera/OperaURLProvider.py
+++ b/Opera/OperaURLProvider.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import re
 import urllib2
 

--- a/Opera/OperaURLProvider.py
+++ b/Opera/OperaURLProvider.py
@@ -58,7 +58,7 @@ class OperaURLProvider(Processor):
                 if ".dmg" in link:
                     url += link
             return url
-        except BaseException as err:
+        except Exception as err:
             raise Exception("Can't read %s: %s" % (url, err))
 
     def main(self):

--- a/Opera/OperaURLProvider.py
+++ b/Opera/OperaURLProvider.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import re
 
 from autopkglib import Processor

--- a/Opera/OperaURLProvider.py
+++ b/Opera/OperaURLProvider.py
@@ -16,10 +16,13 @@
 
 from __future__ import absolute_import
 import re
-import urllib2
 
 from autopkglib import Processor
 
+try:
+    from urllib.request import urlopen  # For Python 3
+except ImportError:
+    from urllib2 import urlopen  # For Python 2
 
 __all__ = ["OperaURLProvider"]
 
@@ -44,11 +47,11 @@ class OperaURLProvider(Processor):
 
     def get_opera_url(self, url):
         try:
-            page = urllib2.urlopen(url).read()
+            page = urlopen(url).read()
             links = re.findall("<a.*?\s*href=\"(.*?)\".*?>", page)
             url += max(links) + "mac/"
 
-            page = urllib2.urlopen(url).read()
+            page = urlopen(url).read()
             links = re.findall("<a.*?\s*href=\"(.*?)\".*?>", page)
             for link in links:
                 if ".dmg" in link:

--- a/Opera/OperaURLProvider.py
+++ b/Opera/OperaURLProvider.py
@@ -49,11 +49,11 @@ class OperaURLProvider(Processor):
     def get_opera_url(self, url):
         try:
             page = urlopen(url).read()
-            links = re.findall("<a.*?\s*href=\"(.*?)\".*?>", page)
+            links = re.findall(r"<a.*?\s*href=\"(.*?)\".*?>", page)
             url += max(links) + "mac/"
 
             page = urlopen(url).read()
-            links = re.findall("<a.*?\s*href=\"(.*?)\".*?>", page)
+            links = re.findall(r"<a.*?\s*href=\"(.*?)\".*?>", page)
             for link in links:
                 if ".dmg" in link:
                     url += link

--- a/ParallelsDesktop/ParallelsURLProvider.py
+++ b/ParallelsDesktop/ParallelsURLProvider.py
@@ -39,7 +39,7 @@ class ParallelsURLProvider(Processor):
     input_variables = {
         "product_name": {
             "required": True,
-            "description": "Product to fetch URL for. One of 'ParallelsDesktop6', 'ParallelsDesktop7', 'ParallelsDesktop8', 'ParallelsDesktop9', 'ParallelsDesktop10'.",
+            "description": "Product to fetch URL for. One of: %s." % ', '.join(URLS),
         },
     }
     output_variables = {
@@ -60,12 +60,11 @@ class ParallelsURLProvider(Processor):
         def compare_version(a, b):
             return cmp(LooseVersion(a), LooseVersion(b))
 
-        valid_prods = URLS.keys()
         prod = self.env.get("product_name")
-        if prod not in valid_prods:
+        if prod not in URLS:
             raise ProcessorError(
                 "product_name %s is invalid; it must be one of: %s" %
-                (prod, valid_prods))
+                (prod, ', '.join(URLS)))
         url = URLS[prod]
         try:
             manifest_str = urllib2.urlopen(url).read()

--- a/ParallelsDesktop/ParallelsURLProvider.py
+++ b/ParallelsDesktop/ParallelsURLProvider.py
@@ -17,12 +17,16 @@
 # limitations under the License.
 
 from __future__ import absolute_import
-import urllib2
 import xml.dom.minidom
 from distutils.version import LooseVersion
 from operator import itemgetter
 
 from autopkglib import Processor, ProcessorError
+
+try:
+    from urllib.request import urlopen  # For Python 3
+except ImportError:
+    from urllib2 import urlopen  # For Python 2
 
 __all__ = ["ParallelsURLProvider"]
 
@@ -67,7 +71,7 @@ class ParallelsURLProvider(Processor):
                 (prod, ', '.join(URLS)))
         url = URLS[prod]
         try:
-            manifest_str = urllib2.urlopen(url).read()
+            manifest_str = urlopen(url).read()
         except BaseException as e:
             raise ProcessorError(
                 "Unexpected error retrieving product manifest: '%s'" %

--- a/ParallelsDesktop/ParallelsURLProvider.py
+++ b/ParallelsDesktop/ParallelsURLProvider.py
@@ -16,6 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import urllib2
 import xml.dom.minidom
 from distutils.version import LooseVersion

--- a/ParallelsDesktop/ParallelsURLProvider.py
+++ b/ParallelsDesktop/ParallelsURLProvider.py
@@ -17,9 +17,9 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import xml.dom.minidom
 from distutils.version import LooseVersion
-from operator import itemgetter
 
 from autopkglib import Processor, ProcessorError
 

--- a/ParallelsDesktop/ParallelsURLProvider.py
+++ b/ParallelsDesktop/ParallelsURLProvider.py
@@ -72,7 +72,7 @@ class ParallelsURLProvider(Processor):
         url = URLS[prod]
         try:
             manifest_str = urlopen(url).read()
-        except BaseException as e:
+        except Exception as e:
             raise ProcessorError(
                 "Unexpected error retrieving product manifest: '%s'" %
                 e)


### PR DESCRIPTION
In order to make your processors more compatible with AutoPkg running in Python 3, I've applied a few adjustments suggested by `python-modernize`, `pylint --py3k`, and `pylint` in general.

More adjustments may need to be made manually later (including moving away from the `cmp()` builtin and finding a replacement for `urllib2.HTTPRedirectHandler`), but this should catch the low-hanging fruit right now.