### PR TITLE
Resolved warning for unused variable `USER_AGENT`

### DIFF
--- a/CarbonCopyCloner/CarbonCopyCloner.download.recipe
+++ b/CarbonCopyCloner/CarbonCopyCloner.download.recipe
@@ -24,11 +24,6 @@
 			<dict>
 				<key>filename</key>
 				<string>%NAME%.zip</string>
-				<key>request_headers</key>
-				<dict>
-					<key>user-agent</key>
-					<string>%USER_AGENT%</string>
-				</dict>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>


### PR DESCRIPTION
Removing the `request_headers` key from the `URLDownloader` processor as the `%USER_AGENT%` variable is not being set or used any more.

Currently running the recipe generates the following warning:
>Use of undefined key in variable substitution: u'USER_AGENT'
