### PR TITLE
fix initial issues with duo recipe

### DIFF
--- a/Duo/Duo Device Health.download.recipe
+++ b/Duo/Duo Device Health.download.recipe
@@ -39,7 +39,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%pathname%/Duo Device Health.app</string>
+				<string>%pathname%/Install-DuoDeviceHealth.pkg</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.duosecurity.duo-device-health" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = FNN8Z5JMFP)</string>
 			</dict>

--- a/Duo/Duo Device Health.munki.recipe
+++ b/Duo/Duo Device Health.munki.recipe
@@ -33,8 +33,26 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>pkg_path</key>
+				<key>dmg_path</key>
 				<string>%pathname%</string>
+				<key>items_to_copy</key>
+				<array>
+					<dict>
+						<key>destination_path</key>
+						<string>%RECIPE_CACHE_DIR%/expanded/</string>
+						<key>source_item</key>
+						<string>Install-DuoDeviceHealth.pkg</string>
+					</dict>
+				</array>
+			</dict>
+			<key>Processor</key>
+			<string>InstallFromDMG</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_path</key>
+				<string>%RECIPE_CACHE_DIR%/expanded/Install-DuoDeviceHealth.pkg</string>
 				<key>repo_subdirectory</key>
 				<string>%MUNKI_REPO_SUBDIR%</string>
 			</dict>


### PR DESCRIPTION
its a pkg in a dmg - codesigning was looking for an app bundle.  added a crude extractor to the munki flow to pass the pkg to the importer.

todo:
probably should add an extractor to get the app bundle out so you can read its info.plist to be sure its the correct version, and get an installs array out then merge it.