### PR TITLE
Use URLGetter, add version output variable, and switch to HTTPS for Opera URL provider

### DIFF
--- a/Opera/OperaURLProvider.py
+++ b/Opera/OperaURLProvider.py
@@ -23,7 +23,7 @@ from autopkglib import Processor, ProcessorError, URLGetter
 __all__ = ["OperaURLProvider"]
 
 
-BASE_URL = "http://get.geo.opera.com/ftp/pub/opera/desktop/"
+BASE_URL = "https://get.geo.opera.com/ftp/pub/opera/desktop/"
 
 
 class OperaURLProvider(URLGetter):


### PR DESCRIPTION
This change reworks the Opera URL provider to use the new [URLGetter superclass](https://github.com/autopkg/autopkg/wiki/Downloading-from-the-Internet-in-Custom-Processors), eliminating the need for urllib2 and easing the transition to Python 3 / AutoPkg 2.

Additionally, I added the Opera version to the output variables. Even though it's not needed for your recipes, it may be useful to others and it was cheap to obtain.

I've also reworked the loop that parses the directory listing to better handle list of versions that aren't already sorted alphabetically, by using `links.remove(max(links))` instead of `links.pop()`. I don't imagine that the directory listing sort direction will change, but just in case this should cover you.

Here's the run log for the download recipe after the change: https://gist.github.com/homebysix/62e1e9cf6d1dce70154ec7d6dc63e887