### PR TITLE
Update Parallels URL provider to use URLGetter

### DIFF
--- a/ParallelsDesktop/ParallelsURLProvider.py
+++ b/ParallelsDesktop/ParallelsURLProvider.py
@@ -21,12 +21,7 @@ from __future__ import absolute_import
 import xml.dom.minidom
 from distutils.version import LooseVersion
 
-from autopkglib import Processor, ProcessorError
-
-try:
-    from urllib.request import urlopen  # For Python 3
-except ImportError:
-    from urllib2 import urlopen  # For Python 2
+from autopkglib import Processor, ProcessorError, URLGetter
 
 __all__ = ["ParallelsURLProvider"]
 
@@ -38,7 +33,7 @@ URLS = {
     "ParallelsDesktop10": "http://update.parallels.com/desktop/v10/parallels/parallels_updates.xml"}
 
 
-class ParallelsURLProvider(Processor):
+class ParallelsURLProvider(URLGetter):
     description = "Provides a version, description, and DMG download for the Parallels product given."
     input_variables = {
         "product_name": {
@@ -71,7 +66,7 @@ class ParallelsURLProvider(Processor):
                 (prod, ', '.join(URLS)))
         url = URLS[prod]
         try:
-            manifest_str = urlopen(url).read()
+            manifest_str = self.download(url)
         except Exception as e:
             raise ProcessorError(
                 "Unexpected error retrieving product manifest: '%s'" %

--- a/ParallelsDesktop/ParallelsURLProvider.py
+++ b/ParallelsDesktop/ParallelsURLProvider.py
@@ -56,9 +56,6 @@ class ParallelsURLProvider(URLGetter):
 
     def main(self):
 
-        def compare_version(a, b):
-            return cmp(LooseVersion(a), LooseVersion(b))
-
         prod = self.env.get("product_name")
         if prod not in URLS:
             raise ProcessorError(


### PR DESCRIPTION
This change reworks the Opera URL provider to use the new [URLGetter superclass](https://github.com/autopkg/autopkg/wiki/Downloading-from-the-Internet-in-Custom-Processors), eliminating the need for urllib2 and easing the transition to Python 3 / AutoPkg 2.

Here's the run log for the download recipe after the change: https://gist.github.com/homebysix/8b936c8a9dd6b0e7db6b0b1b179b02f8