### PR TITLE
Update Flux.download recipe

### DIFF
--- a/Flux/Flux.download.recipe
+++ b/Flux/Flux.download.recipe
@@ -11,7 +11,7 @@
 		<key>NAME</key>
 		<string>Flux</string>
 		<key>SPARKLE_FEED_URL</key>
-		<string>https://herf.org/flux/macflux.xml</string>
+		<string>https://justgetflux.com/mac/macflux.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.2.0</string>


### PR DESCRIPTION
It looks like the Sparkle feed has changed, and the old one is producing errors. This one works.