### PR TITLE
FoundationPlist -> plistlib

### DIFF
--- a/GoogleTalkPlugin/MunkiPkginfoReceiptsEditor.py
+++ b/GoogleTalkPlugin/MunkiPkginfoReceiptsEditor.py
@@ -3,7 +3,7 @@
 from __future__ import absolute_import
 
 from autopkglib import Processor, ProcessorError
-from FoundationPlist import readPlist, writePlist
+from plistlib import readPlist, writePlist
 
 __all__ = ["MunkiPkginfoReceiptsEditor"]
 


### PR DESCRIPTION
Replace FoundationPlist, which has been retired in AutoPkg 2, with plistlib