### PR TITLE
Update sparkle feed url for duo device health recipe

### DIFF
--- a/Duo/Duo Device Health.download.recipe
+++ b/Duo/Duo Device Health.download.recipe
@@ -9,7 +9,7 @@
 		<key>NAME</key>
 		<string>Duo Device Health</string>
 		<key>SPARKLE_FEED_URL</key>
-		<string>https://dl.duosecurity.com/DuoDeviceHealth-appcast-macos-latest.xml</string>
+		<string>https://dl.duosecurity.com/DuoDeviceHealth-appcast-v2-macos-latest.xml</string>
 	</dict>
 	<key>Process</key>
 	<array>


### PR DESCRIPTION
At some point duo started using a new feed url.

~~~shell
defaults read /Applications/Duo\ Device\ Health.app/Contents/Info.plist SUFeedURL
https://dl.duosecurity.com/DuoDeviceHealth-appcast-v2-macos-latest.xml
~~~