### PR TITLE
Update Stay.download.recipe

### DIFF
--- a/CordlessDog/Stay.download.recipe
+++ b/CordlessDog/Stay.download.recipe
@@ -27,12 +27,30 @@
 			<string>SparkleUpdateInfoProvider</string>
 		</dict>
 		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>filename</key>
+				<string>%NAME%-%version%.dmg</string>
+			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>
 			<string>EndOfCheckPhase</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>input_path</key>
+				<string>%pathname%/Stay.app</string>
+				<key>requirement</key>
+				<string>identifier "com.cordlessdog.Stay" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = N87J278237</string>
+				<key>strict_verification</key>
+				<true/>
+			</dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
 		</dict>
 	</array>
 </dict>


### PR DESCRIPTION
- Define filename in URLDownloader processor, since the default file is `Stay%201.3.dmg`.
- Add missing CodeSignatureVerifier processor

Verbose recipe output:

```
autopkg run ~/Documents/git/keeleysam-recipes/CordlessDog/Stay.download.recipe -vv
Processing /Users/admin/Documents/git/keeleysam-recipes/CordlessDog/Stay.download.recipe...
WARNING: /Users/admin/Documents/git/keeleysam-recipes/CordlessDog/Stay.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://cordlessdog.com/stay/appcast.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 518
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 1.3
SparkleUpdateInfoProvider: Found URL https://cordlessdog.com/stay/versions/Stay%201.3.dmg
{'Output': {'url': 'https://cordlessdog.com/stay/versions/Stay%201.3.dmg',
            'version': '1.3'}}
URLDownloader
{'Input': {'filename': 'Stay-1.3.dmg',
           'url': 'https://cordlessdog.com/stay/versions/Stay%201.3.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Thu, 30 Apr 2020 12:10:50 GMT
URLDownloader: Storing new ETag header: "7466a8-5a480f4a548e1"
URLDownloader: Downloaded /Users/admin/Library/AutoPkg/Cache/com.github.keeleysam.recipes.Stay.download/downloads/Stay-1.3.dmg
{'Output': {'download_changed': True,
            'etag': '"7466a8-5a480f4a548e1"',
            'last_modified': 'Thu, 30 Apr 2020 12:10:50 GMT',
            'pathname': '/Users/admin/Library/AutoPkg/Cache/com.github.keeleysam.recipes.Stay.download/downloads/Stay-1.3.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '/Users/admin/Library/AutoPkg/Cache/com.github.keeleysam.recipes.Stay.download/downloads/Stay-1.3.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '/Users/admin/Library/AutoPkg/Cache/com.github.keeleysam.recipes.Stay.download/downloads/Stay-1.3.dmg/Stay.app',
           'requirement': 'identifier "com.cordlessdog.Stay" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'N87J278237',
           'strict_verification': True}}
CodeSignatureVerifier: Mounted disk image /Users/admin/Library/AutoPkg/Cache/com.github.keeleysam.recipes.Stay.download/downloads/Stay-1.3.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification enabled...
CodeSignatureVerifier: /private/tmp/dmg.UDSa8u/Stay.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.UDSa8u/Stay.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.UDSa8u/Stay.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to /Users/admin/Library/AutoPkg/Cache/com.github.keeleysam.recipes.Stay.download/receipts/Stay.download-receipt-20201003-010724.plist

The following new items were downloaded:
    Download Path                                                                                       
    -------------                                                                                       
    /Users/admin/Library/AutoPkg/Cache/com.github.keeleysam.recipes.Stay.download/downloads/Stay-1.3.dmg 
```