### PR TITLE
Update iStat Menu recipes

### DIFF
--- a/Bjango/iStatMenus.download.recipe
+++ b/Bjango/iStatMenus.download.recipe
@@ -9,7 +9,7 @@
 		<key>DOWNLOAD_URL</key>
 		<string>https://download.bjango.com/istatmenus/</string>
 		<key>NAME</key>
-		<string>Opera</string>
+		<string>iStatMenus</string>
 		<key>USER_AGENT</key>
 		<string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_3) AppleWebKit/536.28.10 (KHTML, like Gecko) Version/6.0.3 Safari/536.28.10</string>
 	</dict>
@@ -36,6 +36,32 @@
 		<dict>
 			<key>Processor</key>
 			<string>EndOfCheckPhase</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>archive_path</key>
+				<string>%pathname%</string>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%</string>
+				<key>purge_destination</key>
+				<true/>
+			</dict>
+			<key>Processor</key>
+			<string>Unarchiver</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>input_path</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/iStat Menus.app</string>
+				<key>requirement</key>
+				<string>anchor apple generic and identifier "com.bjango.istatmenus" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = Y93TK974AT)</string>
+				<key>strict_verification</key>
+				<true/>
+			</dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
 		</dict>
 	</array>
 </dict>

--- a/Bjango/iStatMenus.munki.recipe
+++ b/Bjango/iStatMenus.munki.recipe
@@ -35,19 +35,6 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>archive_path</key>
-				<string>%pathname%</string>
-				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%</string>
-				<key>purge_destination</key>
-				<true/>
-			</dict>
-			<key>Processor</key>
-			<string>Unarchiver</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
 				<key>dmg_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
 				<key>dmg_root</key>


### PR DESCRIPTION
- Move Unarchiver from munki recipe to download recipe
- Add missing CodeSignatureVerifier
- Set default NAME input variable to iStatMenus

Verbose recipe run;

```
autopkg run ~/Documents/git/keeleysam-recipes/Bjango/iStatMenus.download.recipe -vv
Processing /Users/admin/Documents/git/keeleysam-recipes/Bjango/iStatMenus.download.recipe...
WARNING: /Users/admin/Documents/git/keeleysam-recipes/Bjango/iStatMenus.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'iStatMenus.zip',
           'request_headers': {'user-agent': 'Mozilla/5.0 (Macintosh; Intel '
                                             'Mac OS X 10_8_3) '
                                             'AppleWebKit/536.28.10 (KHTML, '
                                             'like Gecko) Version/6.0.3 '
                                             'Safari/536.28.10'},
           'url': 'https://download.bjango.com/istatmenus/'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Tue, 19 Nov 2019 07:08:13 GMT
URLDownloader: Storing new ETag header: "5dd394dd-16b1075"
URLDownloader: Downloaded /Users/admin/Library/AutoPkg/Cache/com.github.keeleysam.recipes.Bjango.iStatMenus.download/downloads/iStatMenus.zip
{'Output': {'download_changed': True,
            'etag': '"5dd394dd-16b1075"',
            'last_modified': 'Tue, 19 Nov 2019 07:08:13 GMT',
            'pathname': '/Users/admin/Library/AutoPkg/Cache/com.github.keeleysam.recipes.Bjango.iStatMenus.download/downloads/iStatMenus.zip',
            'url_downloader_summary_result': {'data': {'download_path': '/Users/admin/Library/AutoPkg/Cache/com.github.keeleysam.recipes.Bjango.iStatMenus.download/downloads/iStatMenus.zip'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '/Users/admin/Library/AutoPkg/Cache/com.github.keeleysam.recipes.Bjango.iStatMenus.download/downloads/iStatMenus.zip',
           'destination_path': '/Users/admin/Library/AutoPkg/Cache/com.github.keeleysam.recipes.Bjango.iStatMenus.download/iStatMenus',
           'purge_destination': True}}
Unarchiver: Guessed archive format 'zip' from filename iStatMenus.zip
Unarchiver: Unarchived /Users/admin/Library/AutoPkg/Cache/com.github.keeleysam.recipes.Bjango.iStatMenus.download/downloads/iStatMenus.zip to /Users/admin/Library/AutoPkg/Cache/com.github.keeleysam.recipes.Bjango.iStatMenus.download/iStatMenus
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '/Users/admin/Library/AutoPkg/Cache/com.github.keeleysam.recipes.Bjango.iStatMenus.download/iStatMenus/iStat '
                         'Menus.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.bjango.istatmenus" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = Y93TK974AT)',
           'strict_verification': True}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification enabled...
CodeSignatureVerifier: /Users/admin/Library/AutoPkg/Cache/com.github.keeleysam.recipes.Bjango.iStatMenus.download/iStatMenus/iStat Menus.app: valid on disk
CodeSignatureVerifier: /Users/admin/Library/AutoPkg/Cache/com.github.keeleysam.recipes.Bjango.iStatMenus.download/iStatMenus/iStat Menus.app: satisfies its Designated Requirement
CodeSignatureVerifier: /Users/admin/Library/AutoPkg/Cache/com.github.keeleysam.recipes.Bjango.iStatMenus.download/iStatMenus/iStat Menus.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to /Users/admin/Library/AutoPkg/Cache/com.github.keeleysam.recipes.Bjango.iStatMenus.download/receipts/iStatMenus.download-receipt-20201004-102147.plist

The following new items were downloaded:
    Download Path                                                                                                      
    -------------                                                                                                      
    /Users/admin/Library/AutoPkg/Cache/com.github.keeleysam.recipes.Bjango.iStatMenus.download/downloads/iStatMenus.zip 
```