### PR TITLE
Remove unused BUNDLE_ID input var

### DIFF
--- a/Duo/Duo Device Health.pkg.recipe
+++ b/Duo/Duo Device Health.pkg.recipe
@@ -6,8 +6,6 @@
 	<string>com.keeleysam.recipes.pkg.DuoDeviceHealth</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.duosecurity.duo-device-health</string>
 		<key>NAME</key>
 		<string>Duo Device Health</string>
 	</dict>


### PR DESCRIPTION
This pull request removes unused instances of `BUNDLE_ID` from recipe input variables, which will help reduce confusion by new AutoPkg users and simplify overrides created from this point on.

Making `BUNDLE_ID` available as an input variable is a common practice in AutoPkg recipes that use the [PkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-PkgCreator) processor ([example](https://github.com/autopkg/homebysix-recipes/blob/4fec9244a3af0f9b7c8f61f35a5cd7f4622fb162/soma-zone/LaunchControl.pkg.recipe#L40-L41)). It's likely that these recipes transitioned from PkgCreator to the more streamlined [AppPkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-AppPkgCreator) processor some time ago, but the now-unused input variable for `BUNDLE_ID` was never removed.

Recipe run output is included below for all changed recipes (excluding jss and install recipe types). Any run failures are very likely to be unrelated to this change.

## ❌ Duo/Duo Device Health.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/keeleysam-recipes/Duo/Duo\ Device\ Health.pkg.recipe
Processing repos/keeleysam-recipes/Duo/Duo Device Health.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://dl.duosecurity.com/DuoDeviceHealth-appcast-v2-macos-latest.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 2.10.0.0
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 2.10.0.0
SparkleUpdateInfoProvider: Found URL https://dl.duosecurity.com/DuoDeviceHealth-2.10.0.0.dmg
{'Output': {'url': 'https://dl.duosecurity.com/DuoDeviceHealth-2.10.0.0.dmg',
            'version': '2.10.0.0'}}
URLDownloader
{'Input': {'filename': 'Duo Device Health-2.10.0.0.dmg',
           'url': 'https://dl.duosecurity.com/DuoDeviceHealth-2.10.0.0.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.keeleysam.recipes.pkg.DuoDeviceHealth/downloads/Duo Device Health-2.10.0.0.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.keeleysam.recipes.pkg.DuoDeviceHealth/downloads/Duo '
                        'Device Health-2.10.0.0.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.keeleysam.recipes.pkg.DuoDeviceHealth/downloads/Duo '
                         'Device '
                         'Health-2.10.0.0.dmg/Install-DuoDeviceHealth.pkg',
           'requirement': 'anchor apple generic and identifier '
                          '"com.duosecurity.duo-device-health" and '
                          '(certificate leaf[field.1.2.840.113635.100.6.1.9] '
                          '/* exists */ or certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'FNN8Z5JMFP)'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.keeleysam.recipes.pkg.DuoDeviceHealth/downloads/Duo Device Health-2.10.0.0.dmg
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "Install-DuoDeviceHealth.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2021-02-02 18:01:33 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Duo Security, Inc. (FNN8Z5JMFP)
CodeSignatureVerifier:        Expires: 2022-04-20 15:40:46 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7B 1B B2 12 4A 4B EC F1 BC 86 5E 94 68 4F A0 2A 45 6A 5F 24 A9 09 
CodeSignatureVerifier:            AD 77 1F 17 F4 E4 37 48 40 47
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03 
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppPkgCreator
{'Input': {'version': '2.10.0.0'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.keeleysam.recipes.pkg.DuoDeviceHealth/downloads/Duo Device Health-2.10.0.0.dmg
Receipt written to ~/Library/AutoPkg/Cache/com.keeleysam.recipes.pkg.DuoDeviceHealth/receipts/Duo Device Health.pkg-receipt-20210213-221045.plist

The following recipes failed:
    repos/keeleysam-recipes/Duo/Duo Device Health.pkg.recipe
        Error in com.keeleysam.recipes.pkg.DuoDeviceHealth: Processor: AppPkgCreator: Error: Error processing path '/private/tmp/dmg.XYe70o/*.app' with glob. 

Nothing downloaded, packaged or imported.
```

