### PR TITLE
remove superfluous pkg unpacking

### DIFF
--- a/Duo/Duo Device Health.download.recipe
+++ b/Duo/Duo Device Health.download.recipe
@@ -23,11 +23,6 @@
 			<string>SparkleUpdateInfoProvider</string>
 		</dict>
 		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>filename</key>
-				<string>%NAME%-%version%.dmg</string>
-			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>
 		</dict>

--- a/Duo/Duo Device Health.munki.recipe
+++ b/Duo/Duo Device Health.munki.recipe
@@ -33,26 +33,8 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>dmg_path</key>
-				<string>%pathname%</string>
-				<key>items_to_copy</key>
-				<array>
-					<dict>
-						<key>destination_path</key>
-						<string>%RECIPE_CACHE_DIR%/expanded/</string>
-						<key>source_item</key>
-						<string>Install-DuoDeviceHealth.pkg</string>
-					</dict>
-				</array>
-			</dict>
-			<key>Processor</key>
-			<string>InstallFromDMG</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
 				<key>pkg_path</key>
-				<string>%RECIPE_CACHE_DIR%/expanded/Install-DuoDeviceHealth.pkg</string>
+				<string>%pathname%</string>
 				<key>repo_subdirectory</key>
 				<string>%MUNKI_REPO_SUBDIR%</string>
 			</dict>


### PR DESCRIPTION
munki handles dmg's just fine... the item on the sparkle feed is even named properly with a hyphen before the version... removed superfluous actions