### PR TITLE
Update Duo Device Health.pkg.recipe

### DIFF
--- a/Duo/Duo Device Health.pkg.recipe
+++ b/Duo/Duo Device Health.pkg.recipe
@@ -19,7 +19,7 @@
 				<key>Arguments</key>
 				<dict>
 					<key>source_pkg</key>
-					<string>%RECIPE_CACHE_DIR%/downloads/%NAME%-%version%.dmg/Install-DuoDeviceHealth.pkg</string>
+					<string>%pathname%/Install-DuoDeviceHealth.pkg</string>
 					<key>pkg_path</key>
 					<string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
 				</dict>


### PR DESCRIPTION
This fixes an error where the DMG fails to mount due to a difference in the %NAME% variable vs. what the DMG is actually called.

Context: https://macadmins.slack.com/archives/C056155B4/p1623336389039500