### PR TITLE
Fix RE_PATTERN for FileZilla download

### DIFF
--- a/FileZilla/FileZilla.download.recipe
+++ b/FileZilla/FileZilla.download.recipe
@@ -11,7 +11,7 @@
 		<key>NAME</key>
 		<string>FileZilla</string>
 		<key>RE_PATTERN</key>
-		<string>&lt;a href=\"(?P&lt;url&gt;http[s]?.*?(?P&lt;filename&gt;FileZilla_(?P&lt;version&gt;[\d.]+)_macosx.*?\.app\.tar\.bz2).*?)\"</string>
+		<string>&lt;a href=\"(?P&lt;url&gt;http[s]?.*?(?P&lt;filename&gt;FileZilla_(?P&lt;version&gt;[\d.]+)_macosx-x86\.tar\.bz2).*?)\"</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>1.0.0</string>

--- a/FileZilla/FileZilla.munki.recipe
+++ b/FileZilla/FileZilla.munki.recipe
@@ -27,8 +27,6 @@
 			<key>unattended_install</key>
 			<true/>
 		</dict>
-		<key>RE_PATTERN</key>
-		<string>&lt;a href=\"(?P&lt;url&gt;http[s]?.*?(?P&lt;filename&gt;FileZilla_(?P&lt;version&gt;[\d.]+)_macosx.*?\.app\.tar\.bz2).*?)\"</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>1.0.0</string>


### PR DESCRIPTION
The download link changed filename. Also, I removed the (duplicat) `RE_PATTERN` value from the `munki` recipe. Was this intended though? I'm always confused about wether to include those patterns in munki recipes or not (potentially causing confusion with overrides in the long term).

Is there a general recommendation for it?