### PR TITLE
Make Opera pkginfo version CFBundleVersion

### DIFF
--- a/Opera/Opera.munki.recipe
+++ b/Opera/Opera.munki.recipe
@@ -37,6 +37,29 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>input_plist_path</key>
+				<string>%RECIPE_CACHE_DIR%/downloads/Opera.dmg/Opera.app/Contents/Info.plist</string>
+				<key>plist_version_key</key>
+				<string>CFBundleVersion</string>
+			</dict>
+			<key>Processor</key>
+			<string>Versioner</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>additional_pkginfo</key>
+				<dict>
+					<key>version</key>
+					<string>%version%</string>
+				</dict>
+			</dict>
+			<key>Processor</key>
+			<string>MunkiPkginfoMerger</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
 				<key>pkg_path</key>
 				<string>%pathname%</string>
 				<key>repo_subdirectory</key>


### PR DESCRIPTION
Propose an update in order to make Opera's CFBundleVersion the resulting Munki pkginfo version due to numerous releases under one ##.# version number. (e.g. 91.0.4516.16, 91.0.4516.20, 91.0.4516.65)