### PR TITLE
Add regex to download the macOS pkg

### DIFF
--- a/osquery/osquery.download.recipe
+++ b/osquery/osquery.download.recipe
@@ -20,6 +20,8 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
+			  <key>asset_regex</key>
+				<string>.*\.pkg</string>
 				<key>github_repo</key>
 				<string>%REPO%</string>
 			</dict>


### PR DESCRIPTION
After getting a Windows zip-file I added a regex to grab the .pkg instead