### PR TITLE
Fix for CarbonCopyCloner download re_pattern

### DIFF
--- a/CarbonCopyCloner/CarbonCopyCloner.download.recipe
+++ b/CarbonCopyCloner/CarbonCopyCloner.download.recipe
@@ -33,7 +33,7 @@ The VERSION key can be overridden with (at the time of writing), three values:
                 <key>url</key>
                 <string>%DOWNLOAD_URL%</string>
                 <key>re_pattern</key>
-                <string>(/software/download_ccc\.php\?v=%VERSION%.*)\"</string>
+                <string>(/software/download_ccc\.php\?v=%VERSION%)\"</string>
                 <key>result_output_var_name</key>
                 <string>match</string>
             </dict>


### PR DESCRIPTION
The extra `.*` on the end of this regex makes it too greedy and ends up grabbing HTML after the URL.