### PR TITLE
Update CarbonCopyCloner.download.recipe

### DIFF
--- a/CarbonCopyCloner/CarbonCopyCloner.download.recipe
+++ b/CarbonCopyCloner/CarbonCopyCloner.download.recipe
@@ -16,8 +16,6 @@ The VERSION key can be overridden with (at the time of writing), three values:
     <dict>
         <key>NAME</key>
         <string>CarbonCopyCloner</string>
-        <key>DOWNLOAD_URL</key>
-        <string>https://bombich.scdn1.secure.raxcdn.com/download</string>
         <key>VERSION</key>
         <string>latest</string>
     </dict>
@@ -27,26 +25,13 @@ The VERSION key can be overridden with (at the time of writing), three values:
     <array>
         <dict>
             <key>Processor</key>
-            <string>URLTextSearcher</string>
-            <key>Arguments</key>
-            <dict>
-                <key>url</key>
-                <string>%DOWNLOAD_URL%</string>
-                <key>re_pattern</key>
-                <string>(/software/download_ccc\.php\?v=%VERSION%.*)\"</string>
-                <key>result_output_var_name</key>
-                <string>match</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
             <string>URLDownloader</string>
             <key>Arguments</key>
             <dict>
                 <key>filename</key>
                 <string>%NAME%.zip</string>
                 <key>url</key>
-                <string>https://bombich.scdn1.secure.raxcdn.com%match%</string>
+                <string>https://bombich.scdn1.secure.raxcdn.com/software/download_ccc.php?v=%VERSION%</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
Hi, @keeleysam 

CarbonCopyCloaner is currently failing with:
```
Processor: URLDownloader: Error: Command '['/usr/bin/curl', '--silent', '--show-error', '--no-buffer', '--dump-header', '-', '--speed-time', '30', '--location', '--url', 'https://bombich.scdn1.secure.raxcdn.com/software/download_ccc.php?v=latest"><i class="fa fa-cloud-download', '--fail', '--output', '/Users/sadmin/Library/AutoPkg/Cache/local.definition.CarbonCopyCloner6/downloads/tmpo35zqw73']' returned non-zero exit status 3.
```

This PR removes the need for 'URLTextSearcher' while keeping support for the existing `VERSION` variable 

Output from a `latest` run
```
autopkg run -v /Users/paul/Documents/GitHub/AutoPkg\ Repos/keeleysam-recipes/CarbonCopyCloner/CarbonCopyCloner.munki.recipe 
Processing /Users/paul/Documents/GitHub/AutoPkg Repos/keeleysam-recipes/CarbonCopyCloner/CarbonCopyCloner.munki.recipe...
WARNING: /Users/paul/Documents/GitHub/AutoPkg Repos/keeleysam-recipes/CarbonCopyCloner/CarbonCopyCloner.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
URLDownloader: Storing new Last-Modified header: Wed, 03 May 2023 19:47:00 GMT
URLDownloader: Downloaded /Users/paul/Library/AutoPkg/Cache/com.github.keeleysam.recipes.CarbonCopyCloner.munki/downloads/CarbonCopyCloner.zip
EndOfCheckPhase
Unarchiver
Unarchiver: Guessed archive format 'zip' from filename CarbonCopyCloner.zip
Unarchiver: Unarchived /Users/paul/Library/AutoPkg/Cache/com.github.keeleysam.recipes.CarbonCopyCloner.munki/downloads/CarbonCopyCloner.zip to /Users/paul/Library/AutoPkg/Cache/com.github.keeleysam.recipes.CarbonCopyCloner.munki/downloads/Applications
CodeSignatureVerifier
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /Users/paul/Library/AutoPkg/Cache/com.github.keeleysam.recipes.CarbonCopyCloner.munki/downloads/Applications/Carbon Copy Cloner.app: valid on disk
CodeSignatureVerifier: /Users/paul/Library/AutoPkg/Cache/com.github.keeleysam.recipes.CarbonCopyCloner.munki/downloads/Applications/Carbon Copy Cloner.app: satisfies its Designated Requirement
CodeSignatureVerifier: /Users/paul/Library/AutoPkg/Cache/com.github.keeleysam.recipes.CarbonCopyCloner.munki/downloads/Applications/Carbon Copy Cloner.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
DmgCreator
DmgCreator: Created dmg from /Users/paul/Library/AutoPkg/Cache/com.github.keeleysam.recipes.CarbonCopyCloner.munki/downloads/Applications/Carbon Copy Cloner.app at /Users/paul/Library/AutoPkg/Cache/com.github.keeleysam.recipes.CarbonCopyCloner.munki/downloads/CarbonCopyCloner.dmg
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/Carbon Copy Cloner/CarbonCopyCloner-6.1.5.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/Carbon Copy Cloner/CarbonCopyCloner-6.1.5.dmg
PathDeleter
PathDeleter: Deleted /Users/paul/Library/AutoPkg/Cache/com.github.keeleysam.recipes.CarbonCopyCloner.munki/downloads/CarbonCopyCloner.dmg
PathDeleter: Deleted /Users/paul/Library/AutoPkg/Cache/com.github.keeleysam.recipes.CarbonCopyCloner.munki/downloads/Applications/
Receipt written to /Users/paul/Library/AutoPkg/Cache/com.github.keeleysam.recipes.CarbonCopyCloner.munki/receipts/CarbonCopyCloner.munki-receipt-20230504-123912.plist

The following new items were downloaded:
    Download Path                                                                                                         
    -------------                                                                                                         
    /Users/paul/Library/AutoPkg/Cache/com.github.keeleysam.recipes.CarbonCopyCloner.munki/downloads/CarbonCopyCloner.zip  

The following new items were imported into Munki:
    Name              Version  Catalogs  Pkginfo Path                                          Pkg Repo Path                                       Icon Repo Path  
    ----              -------  --------  ------------                                          -------------                                       --------------  
    CarbonCopyCloner  6.1.5    testing   apps/Carbon Copy Cloner/CarbonCopyCloner-6.1.5.plist  apps/Carbon Copy Cloner/CarbonCopyCloner-6.1.5.dmg
```

Output from a `ccc5` run
```
autopkg run -v /Users/paul/Documents/GitHub/AutoPkg\ Repos/keeleysam-recipes/CarbonCopyCloner/CarbonCopyCloner.munki.recipe 
Processing /Users/paul/Documents/GitHub/AutoPkg Repos/keeleysam-recipes/CarbonCopyCloner/CarbonCopyCloner.munki.recipe...
WARNING: /Users/paul/Documents/GitHub/AutoPkg Repos/keeleysam-recipes/CarbonCopyCloner/CarbonCopyCloner.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
URLDownloader: Storing new Last-Modified header: Wed, 03 May 2023 19:47:00 GMT
URLDownloader: Downloaded /Users/paul/Library/AutoPkg/Cache/com.github.keeleysam.recipes.CarbonCopyCloner.munki/downloads/CarbonCopyCloner.zip
EndOfCheckPhase
Unarchiver
Unarchiver: Guessed archive format 'zip' from filename CarbonCopyCloner.zip
Unarchiver: Unarchived /Users/paul/Library/AutoPkg/Cache/com.github.keeleysam.recipes.CarbonCopyCloner.munki/downloads/CarbonCopyCloner.zip to /Users/paul/Library/AutoPkg/Cache/com.github.keeleysam.recipes.CarbonCopyCloner.munki/downloads/Applications
CodeSignatureVerifier
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /Users/paul/Library/AutoPkg/Cache/com.github.keeleysam.recipes.CarbonCopyCloner.munki/downloads/Applications/Carbon Copy Cloner.app: valid on disk
CodeSignatureVerifier: /Users/paul/Library/AutoPkg/Cache/com.github.keeleysam.recipes.CarbonCopyCloner.munki/downloads/Applications/Carbon Copy Cloner.app: satisfies its Designated Requirement
CodeSignatureVerifier: /Users/paul/Library/AutoPkg/Cache/com.github.keeleysam.recipes.CarbonCopyCloner.munki/downloads/Applications/Carbon Copy Cloner.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
DmgCreator
DmgCreator: Created dmg from /Users/paul/Library/AutoPkg/Cache/com.github.keeleysam.recipes.CarbonCopyCloner.munki/downloads/Applications/Carbon Copy Cloner.app at /Users/paul/Library/AutoPkg/Cache/com.github.keeleysam.recipes.CarbonCopyCloner.munki/downloads/CarbonCopyCloner.dmg
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/Carbon Copy Cloner/CarbonCopyCloner-5.1.28.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/Carbon Copy Cloner/CarbonCopyCloner-5.1.28.dmg
PathDeleter
PathDeleter: Deleted /Users/paul/Library/AutoPkg/Cache/com.github.keeleysam.recipes.CarbonCopyCloner.munki/downloads/CarbonCopyCloner.dmg
PathDeleter: Deleted /Users/paul/Library/AutoPkg/Cache/com.github.keeleysam.recipes.CarbonCopyCloner.munki/downloads/Applications/
Receipt written to /Users/paul/Library/AutoPkg/Cache/com.github.keeleysam.recipes.CarbonCopyCloner.munki/receipts/CarbonCopyCloner.munki-receipt-20230504-124027.plist

The following new items were downloaded:
    Download Path                                                                                                         
    -------------                                                                                                         
    /Users/paul/Library/AutoPkg/Cache/com.github.keeleysam.recipes.CarbonCopyCloner.munki/downloads/CarbonCopyCloner.zip  

The following new items were imported into Munki:
    Name              Version  Catalogs  Pkginfo Path                                           Pkg Repo Path                                        Icon Repo Path  
    ----              -------  --------  ------------                                           -------------                                        --------------  
    CarbonCopyCloner  5.1.28   testing   apps/Carbon Copy Cloner/CarbonCopyCloner-5.1.28.plist  apps/Carbon Copy Cloner/CarbonCopyCloner-5.1.28.dmg 
```

Output from a `latestbeta` run
```
autopkg run -v /Users/paul/Documents/GitHub/AutoPkg\ Repos/keeleysam-recipes/CarbonCopyCloner/CarbonCopyCloner.munki.recipe 
Processing /Users/paul/Documents/GitHub/AutoPkg Repos/keeleysam-recipes/CarbonCopyCloner/CarbonCopyCloner.munki.recipe...
WARNING: /Users/paul/Documents/GitHub/AutoPkg Repos/keeleysam-recipes/CarbonCopyCloner/CarbonCopyCloner.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
URLDownloader: Storing new Last-Modified header: Wed, 03 May 2023 19:47:00 GMT
URLDownloader: Downloaded /Users/paul/Library/AutoPkg/Cache/com.github.keeleysam.recipes.CarbonCopyCloner.munki/downloads/CarbonCopyCloner.zip
EndOfCheckPhase
Unarchiver
Unarchiver: Guessed archive format 'zip' from filename CarbonCopyCloner.zip
Unarchiver: Unarchived /Users/paul/Library/AutoPkg/Cache/com.github.keeleysam.recipes.CarbonCopyCloner.munki/downloads/CarbonCopyCloner.zip to /Users/paul/Library/AutoPkg/Cache/com.github.keeleysam.recipes.CarbonCopyCloner.munki/downloads/Applications
CodeSignatureVerifier
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /Users/paul/Library/AutoPkg/Cache/com.github.keeleysam.recipes.CarbonCopyCloner.munki/downloads/Applications/Carbon Copy Cloner.app: valid on disk
CodeSignatureVerifier: /Users/paul/Library/AutoPkg/Cache/com.github.keeleysam.recipes.CarbonCopyCloner.munki/downloads/Applications/Carbon Copy Cloner.app: satisfies its Designated Requirement
CodeSignatureVerifier: /Users/paul/Library/AutoPkg/Cache/com.github.keeleysam.recipes.CarbonCopyCloner.munki/downloads/Applications/Carbon Copy Cloner.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
DmgCreator
DmgCreator: Created dmg from /Users/paul/Library/AutoPkg/Cache/com.github.keeleysam.recipes.CarbonCopyCloner.munki/downloads/Applications/Carbon Copy Cloner.app at /Users/paul/Library/AutoPkg/Cache/com.github.keeleysam.recipes.CarbonCopyCloner.munki/downloads/CarbonCopyCloner.dmg
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/Carbon Copy Cloner/CarbonCopyCloner-6.1.6-b2.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/Carbon Copy Cloner/CarbonCopyCloner-6.1.6-b2.dmg
PathDeleter
PathDeleter: Deleted /Users/paul/Library/AutoPkg/Cache/com.github.keeleysam.recipes.CarbonCopyCloner.munki/downloads/CarbonCopyCloner.dmg
PathDeleter: Deleted /Users/paul/Library/AutoPkg/Cache/com.github.keeleysam.recipes.CarbonCopyCloner.munki/downloads/Applications/
Receipt written to /Users/paul/Library/AutoPkg/Cache/com.github.keeleysam.recipes.CarbonCopyCloner.munki/receipts/CarbonCopyCloner.munki-receipt-20230504-124202.plist

The following new items were downloaded:
    Download Path                                                                                                         
    -------------                                                                                                         
    /Users/paul/Library/AutoPkg/Cache/com.github.keeleysam.recipes.CarbonCopyCloner.munki/downloads/CarbonCopyCloner.zip  

The following new items were imported into Munki:
    Name              Version   Catalogs  Pkginfo Path                                             Pkg Repo Path                                          Icon Repo Path  
    ----              -------   --------  ------------                                             -------------                                          --------------  
    CarbonCopyCloner  6.1.6-b2  testing   apps/Carbon Copy Cloner/CarbonCopyCloner-6.1.6-b2.plist  apps/Carbon Copy Cloner/CarbonCopyCloner-6.1.6-b2.dmg
```