### PR TITLE
Update Duo Desktop.munki.recipe

### DIFF
--- a/Duo/Duo Desktop.munki.recipe
+++ b/Duo/Duo Desktop.munki.recipe
@@ -2,10 +2,16 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>Description</key>
+	<string>Downloads the latest version of Duo Desktop and imports into Munki.
+
+Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7 please update if you're not already running it.</string>
 	<key>Identifier</key>
 	<string>com.keeleysam.recipes.munki.DuoDesktop</string>
 	<key>Input</key>
 	<dict>
+		<key>DERIVE_MIN_OS</key>
+		<string>YES</string>
 		<key>MUNKI_REPO_SUBDIR</key>
 		<string>apps/%NAME%</string>
 		<key>NAME</key>
@@ -22,8 +28,8 @@
 			<string>Duo Desktop</string>
 			<key>name</key>
 			<string>%NAME%</string>
-            <key>preinstall_script</key>
-            <string>#!/bin/bash
+			<key>preinstall_script</key>
+			<string>#!/bin/bash
 
 # If running macOS 11+ then write out this file to allow installation to proceed.
 # Needs MDM to deliver a cert profile, as per: https://duo.com/docs/device-health
@@ -31,41 +37,69 @@
 # Get darwin version, pinched, with &lt;33 from: https://stackoverflow.com/a/39499208
 # Arguably a cleaner way to detect OS.
 
+CREATEDEVICEHEALTHDIRECTORY="/Library/Application Support/Duo/Duo Device Health"
+DISABLECERT="/Library/Application Support/Duo/Duo Device Health/DisableMacOS11CertManagement"
+
 if [[ ${OSTYPE:6} -ge 21 ]]
 then
-    /usr/bin/touch "/Library/Application Support/Duo/Duo Device Health/DisableMacOS11CertManagement"
+	/bin/mkdir -p "$CREATEDEVICEHEALTHDIRECTORY"
+	/usr/bin/touch "$DISABLECERT"
 fi</string>
 			<key>unattended_install</key>
 			<true/>
 		</dict>
 	</dict>
+	<key>MinimumVersion</key>
+	<string>2.7</string>
 	<key>ParentRecipe</key>
 	<string>com.keeleysam.recipes.download.DuoDesktop</string>
 	<key>Process</key>
 	<array>
 		<dict>
-		<key>Arguments</key>
-		<dict>
-			<key>additional_pkginfo</key>
+			<key>Arguments</key>
 			<dict>
-				<key>installs</key>
-				<array>
-					<dict>
-						<key>CFBundleShortVersionString</key>
-						<string>%version%</string>
-						<key>path</key>
-						<string>/Applications/Duo Desktop.app</string>
-						<key>type</key>
-						<string>application</string>
-						<key>version_comparison_key</key>
-						<string>CFBundleShortVersionString</string>
-					</dict>
-				</array>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/unpacked</string>
+				<key>flat_pkg_path</key>
+				<string>%pathname%</string>
+				<key>purge_destination</key>
+				<true/>
 			</dict>
+			<key>Processor</key>
+			<string>FlatPkgUnpacker</string>
 		</dict>
-		<key>Processor</key>
-		<string>MunkiPkginfoMerger</string>
-	</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/Applications</string>
+				<key>pkg_payload_path</key>
+				<string>%RECIPE_CACHE_DIR%/unpacked/DuoDesktop.pkg/Payload</string>
+				<key>purge_destination</key>
+				<true/>
+			</dict>
+			<key>Processor</key>
+			<string>PkgPayloadUnpacker</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>faux_root</key>
+				<string>%RECIPE_CACHE_DIR%</string>
+				<key>installs_item_paths</key>
+				<array>
+					<string>/Applications/%NAME%.app</string>
+				</array>
+				<key>derive_minimum_os_version</key>
+				<string>%DERIVE_MIN_OS%</string>
+			</dict>
+			<key>Processor</key>
+			<string>MunkiInstallsItemsCreator</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>MunkiPkginfoMerger</string>
+		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>
@@ -76,6 +110,18 @@ fi</string>
 			</dict>
 			<key>Processor</key>
 			<string>MunkiImporter</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>path_list</key>
+				<array>
+					<string>%RECIPE_CACHE_DIR%/unpacked</string>
+					<string>%RECIPE_CACHE_DIR%/Applications</string>
+				</array>
+			</dict>
+			<key>Processor</key>
+			<string>PathDeleter</string>
 		</dict>
 	</array>
 </dict>


### PR DESCRIPTION
Hi, @keeleysam 

The current preinstall script will fail if the directory `/Library/Application Support/Duo/Duo Device Health` isn't there. 
```
touch: /Library/Application Support/Duo/Duo Device Health/DisableMacOS11CertManagement: No such file or directory
```

This PR updates it so that it creates the path if it's not already present. 

I've also taken the opportunity to enhance the Installs Array creation by using `MunkiInstallsItemsCreator` to build it from the App bundle with support for `derive_minimum_os_version`

Output from a successful verbose run

```
autopkg run -v Duo\ Desktop.munki.recipe
Looking for com.keeleysam.recipes.download.DuoDesktop...
Did not find com.keeleysam.recipes.download.DuoDesktop in recipe map
Rebuilding recipe map with current working directories...
Looking for com.keeleysam.recipes.download.DuoDesktop...
Found com.keeleysam.recipes.download.DuoDesktop in recipe map
**load_recipe time: 0.0039040000001477893
Processing Duo Desktop.munki.recipe...
WARNING: Duo Desktop.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
URLTextSearcher: Found matching text (version): 6.0.0.0
URLDownloader
URLDownloader: Storing new Last-Modified header: Tue, 31 Oct 2023 13:09:34 GMT
URLDownloader: Storing new ETag header: "e3281bd428336b6017b7c4cc23b97c3e"
URLDownloader: Downloaded /Users/paul.cossey/Library/AutoPkg/Cache/com.keeleysam.recipes.munki.DuoDesktop/downloads/DuoDesktop-6.0.0.0.pkg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "DuoDesktop-6.0.0.0.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2023-10-30 16:30:57 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Duo Security LLC (FNN8Z5JMFP)
CodeSignatureVerifier:        Expires: 2027-02-12 17:19:45 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            C6 C7 63 E5 7A 64 92 6E 47 63 68 4E 16 36 F2 EB EF F9 92 63 BF 58 
CodeSignatureVerifier:            03 B3 9F E7 72 BB 86 97 61 08
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2031-09-17 00:00:00 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            F1 6C D3 C5 4C 7F 83 CE A4 BF 1A 3E 6A 08 19 C8 AA A8 E4 A1 52 8F 
CodeSignatureVerifier:            D1 44 71 5F 35 06 43 D2 DF 3A
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
FlatPkgUnpacker
FlatPkgUnpacker: Unpacked /Users/paul.cossey/Library/AutoPkg/Cache/com.keeleysam.recipes.munki.DuoDesktop/downloads/DuoDesktop-6.0.0.0.pkg to /Users/paul.cossey/Library/AutoPkg/Cache/com.keeleysam.recipes.munki.DuoDesktop/unpacked
PkgPayloadUnpacker
PkgPayloadUnpacker: Unpacked /Users/paul.cossey/Library/AutoPkg/Cache/com.keeleysam.recipes.munki.DuoDesktop/unpacked/DuoDesktop.pkg/Payload to /Users/paul.cossey/Library/AutoPkg/Cache/com.keeleysam.recipes.munki.DuoDesktop/Applications
MunkiInstallsItemsCreator
MunkiInstallsItemsCreator: Created installs item for /Applications/Duo Desktop.app
MunkiInstallsItemsCreator: Derived minimum os version as: 10.15
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'installs': [{'CFBundleIdentifier': 'com.duosecurity.duo-device-health', 'CFBundleName': 'Duo Desktop', 'CFBundleShortVersionString': '6.0.0.0', 'CFBundleVersion': '6.0.0.0', 'minosversion': '10.15', 'path': '/Applications/Duo Desktop.app', 'type': 'application', 'version_comparison_key': 'CFBundleShortVersionString'}], 'minimum_os_version': '10.15'} into pkginfo
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/Duo Desktop/Duo Desktop-6.0.0.0.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/Duo Desktop/DuoDesktop-6.0.0.0.pkg
PathDeleter
PathDeleter: Deleted /Users/paul.cossey/Library/AutoPkg/Cache/com.keeleysam.recipes.munki.DuoDesktop/unpacked
PathDeleter: Deleted /Users/paul.cossey/Library/AutoPkg/Cache/com.keeleysam.recipes.munki.DuoDesktop/Applications
Receipt written to /Users/paul.cossey/Library/AutoPkg/Cache/com.keeleysam.recipes.munki.DuoDesktop/receipts/Duo Desktop.munki-receipt-20231108-100807.plist

The following new items were downloaded:
    Download Path                                                                                                     
    -------------                                                                                                     
    /Users/paul.cossey/Library/AutoPkg/Cache/com.keeleysam.recipes.munki.DuoDesktop/downloads/DuoDesktop-6.0.0.0.pkg  

The following new items were imported into Munki:
    Name         Version  Catalogs    Pkginfo Path                                Pkg Repo Path                            Icon Repo Path  
    ----         -------  --------    ------------                                -------------                            --------------  
    Duo Desktop  6.0.0.0  production  apps/Duo Desktop/Duo Desktop-6.0.0.0.plist  apps/Duo Desktop/DuoDesktop-6.0.0.0.pkg
```
