### PR TITLE
fix that they dropped x from macos, add arch

### DIFF
--- a/FileZilla/FileZilla.download.recipe
+++ b/FileZilla/FileZilla.download.recipe
@@ -10,8 +10,11 @@
 	<dict>
 		<key>NAME</key>
 		<string>FileZilla</string>
+		<!-- valid options for mac are x86 or arm64 for Apple Silicon -->
+		<key>ARCH</key>
+		<string>x86</string>
 		<key>RE_PATTERN</key>
-		<string>&lt;a href=\"(?P&lt;url&gt;http[s]?.*?(?P&lt;filename&gt;FileZilla_(?P&lt;version&gt;[\d.]+)_macosx-x86.*?\.tar\.bz2).*?)\"</string>
+		<string>&lt;a href=\"(?P&lt;url&gt;http[s]?.*?(?P&lt;filename&gt;FileZilla_(?P&lt;version&gt;[\d.]+)_macos-%ARCH%.*?\.tar\.bz2).*?)\"</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>1.0.0</string>


### PR DESCRIPTION
arm64 is available so I added a comment indicating that but the folks using this recipe asked for intel to be default so I just updated the regex and left the arch