### PR TITLE
Update all available URLs from HTTP to HTTPS

### DIFF
--- a/Colloquy/Colloquy.download.recipe
+++ b/Colloquy/Colloquy.download.recipe
@@ -11,7 +11,7 @@
 		<key>NAME</key>
 		<string>Colloquy</string>
 		<key>SPARKLE_FEED_URL</key>
-		<string>http://colloquy.info/update.php?rss</string>
+		<string>https://colloquy.info/update.php?rss</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.2.0</string>

--- a/StuffIt/StuffItExpander.download.recipe
+++ b/StuffIt/StuffItExpander.download.recipe
@@ -9,7 +9,7 @@
 		<key>NAME</key>
 		<string>StuffItExpander</string>
 		<key>SPARKLE_FEED_URL</key>
-		<string>http://www.stuffit.com/update_rss/NEU/StuffItExpanderUpdates.xml</string>
+		<string>https://www.stuffit.com/update_rss/NEU/StuffItExpanderUpdates.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.2.1</string>


### PR DESCRIPTION
It's important to use HTTPS for downloading software whenever possible in order to avoid the possibility of person-in-the-middle attacks (like the one that affected the Sparkle update framework [in January 2016](https://vulnsec.com/2016/osx-apps-vulnerabilities/)).

For this pull request, I detected and changed to HTTPS URLs automatically using my [HTTPS Spotter](https://www.elliotjordan.com/posts/autopkg-https/) script, and then tested all changed recipes manually to ensure exit codes of recipe run remains the same before/after the change.

This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso).

Thanks for considering!