### PR TITLE
[Duo Desktop] allow multi-digit version numbers

### DIFF
--- a/Duo/Duo Desktop.download.recipe
+++ b/Duo/Duo Desktop.download.recipe
@@ -19,7 +19,7 @@
 				<key>url</key>
 				<string>https://duo.com/docs/checksums#macos</string>
 				<key>re_pattern</key>
-				<string>href="https://dl.duosecurity.com/DuoDesktop-(\d\.\d\.\d\.\d)\.pkg"</string>
+				<string>href="https://dl.duosecurity.com/DuoDesktop-(\d+\.\d+\.\d+\.\d+)\.pkg"</string>
 				<key>result_output_var_name</key>
 				<string>version</string>
 			</dict>


### PR DESCRIPTION
Duo Desktop 6.10.0.0 was released, but the recipe didn't find it because the existing regex only matches single digits.

This PR allows unlimited digits in each version component.