### PR TITLE
Fix Zulip recipes and add code signature verification

### DIFF
--- a/Zulip/Zulip.download.recipe
+++ b/Zulip/Zulip.download.recipe
@@ -9,7 +9,7 @@
 	<key>Input</key>
 	<dict>
 		<key>DOWNLOAD_URL</key>
-		<string>https://zulip.com/dist/apps/mac/Zulip-latest.dmg</string>
+		<string>https://zulip.com/apps/download/mac</string>
 		<key>NAME</key>
 		<string>Zulip</string>
 	</dict>

--- a/Zulip/Zulip.download.recipe
+++ b/Zulip/Zulip.download.recipe
@@ -32,6 +32,17 @@
 			<key>Processor</key>
 			<string>EndOfCheckPhase</string>
 		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>input_path</key>
+				<string>%pathname%/Zulip.app</string>
+				<key>requirement</key>
+				<string>identifier "org.zulip.zulip-electron" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "66KHCWMEYB"</string>
+			</dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
+		</dict>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
This PR fixes the Zulip download URL and adds code signature verification.

Verbose recipe run output:

```
% autopkg run -vvq 'Zulip/Zulip.download.recipe'
Processing Zulip/Zulip.download.recipe...
WARNING: Zulip/Zulip.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'Zulip.dmg',
           'url': 'https://zulip.com/apps/download/mac'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Fri, 23 Aug 2024 23:52:56 GMT
URLDownloader: Storing new ETag header: "0x8DCC3CEB64D8E2D"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.zulip.download/downloads/Zulip.dmg
{'Output': {'download_changed': True,
            'etag': '"0x8DCC3CEB64D8E2D"',
            'last_modified': 'Fri, 23 Aug 2024 23:52:56 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.zulip.download/downloads/Zulip.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.zulip.download/downloads/Zulip.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.zulip.download/downloads/Zulip.dmg/Zulip.app',
           'requirement': 'identifier "org.zulip.zulip-electron" and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"66KHCWMEYB"'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.zulip.download/downloads/Zulip.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.OJ17pd/Zulip.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.OJ17pd/Zulip.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.OJ17pd/Zulip.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.zulip.download/receipts/Zulip.download-receipt-20241226-222158.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.zulip.download/downloads/Zulip.dmg
```
