### PR TITLE
Deprecate WinClone recipes

### DIFF
--- a/Twocanoes/WinclonePro4.download.recipe
+++ b/Twocanoes/WinclonePro4.download.recipe
@@ -16,9 +16,13 @@
 		<string>Winclone Pro/4.1 Sparkle/313</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.1</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>


### PR DESCRIPTION
This PR deprecates the WinClone (version 4) recipes, which are not currently working. WinClone 10 is the latest version.
