### PR TITLE
Deprecate Bartender 2 recipes

### DIFF
--- a/SurteesStudios/Bartender.download.recipe
+++ b/SurteesStudios/Bartender.download.recipe
@@ -20,6 +20,15 @@
 	<key>Process</key>
 	<array>
 		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>Consider switching to the Bartender recipes in the homebysix-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>appcast_request_headers</key>


### PR DESCRIPTION
This PR deprecates the Bartender (version 2) recipes, which are not currently working, and points users to Bartender 5 recipes in my homebysix-recipes repo instead.