### PR TITLE
Deprecate SublimeText2 recipes

### DIFF
--- a/SublimeText/SublimeText2.download.recipe
+++ b/SublimeText/SublimeText2.download.recipe
@@ -14,9 +14,18 @@
 		<string>https://www.sublimetext.com/updates/2/stable/appcast_osx.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.1</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>Consider switching to the SublimeText4 recipes in the gregneagle-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>


### PR DESCRIPTION
This PR deprecates the SublimeText 2 recipes, since version 4 is the latest available.
