### PR TITLE
Deprecate InsomniaX recipes

### DIFF
--- a/InsomniaX/InsomniaX.download.recipe
+++ b/InsomniaX/InsomniaX.download.recipe
@@ -18,6 +18,15 @@
 	<key>Process</key>
 	<array>
 		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>InsomniaX is no longer available for download (details: https://github.com/semaja2/InsomniaX). This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>appcast_url</key>


### PR DESCRIPTION
InsomniaX is no longer available for download ([details](https://github.com/semaja2/InsomniaX)). This PR deprecates the InsomniaX recipes.
