### PR TITLE
Deprecate GitHub recipes

### DIFF
--- a/Github/Github.download.recipe
+++ b/Github/Github.download.recipe
@@ -12,9 +12,18 @@
 		<string>GitHub</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.4.1</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the GitHubDesktop recipes in the homebysix-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>


### PR DESCRIPTION
This PR deprecates the non-working GitHub recipes and points users to alternatives in my homebysix-recipes repo.
