### PR TITLE
Use GitHub releases as download source for Colloquy

### DIFF
--- a/Colloquy/Colloquy.download.recipe
+++ b/Colloquy/Colloquy.download.recipe
@@ -10,8 +10,6 @@
 	<dict>
 		<key>NAME</key>
 		<string>Colloquy</string>
-		<key>SPARKLE_FEED_URL</key>
-		<string>https://colloquy.info/update.php?rss</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.2.0</string>
@@ -20,11 +18,15 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>appcast_url</key>
-				<string>%SPARKLE_FEED_URL%</string>
+				<key>github_repo</key>
+				<string>colloquy/colloquy</string>
+				<key>asset_regex</key>
+				<string>Colloquy.+\.zip</string>
+				<key>include_prereleases</key>
+				<false/>
 			</dict>
 			<key>Processor</key>
-			<string>SparkleUpdateInfoProvider</string>
+			<string>GitHubReleasesInfoProvider</string>
 		</dict>
 		<dict>
 			<key>Processor</key>


### PR DESCRIPTION
Colloquy's Sparkle feed is no longer working, but there appears to be activity a couple years ago in the GitHub repo, including some prereleases.

This pull request adjusts the download source for Colloquy to GitHub, so that if a release becomes available, it will be downloaded.

Code signature verification has not been added yet, because the prereleases are not signed.

Testing verbose recipe run with `include_prereleases` enabled, to prove it works:

```
% autopkg run -vvq 'Colloquy/Colloquy.download.recipe'
Processing Colloquy/Colloquy.download.recipe...
WARNING: Colloquy/Colloquy.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
GitHubReleasesInfoProvider
{'Input': {'asset_regex': 'Colloquy.+\\.zip',
           'github_repo': 'colloquy/colloquy',
           'include_prereleases': True}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: No value supplied for GITHUB_URL, setting default value of: https://api.github.com
GitHubReleasesInfoProvider: No value supplied for GITHUB_TOKEN_PATH, setting default value of: ~/.autopkg_gh_token
GitHubReleasesInfoProvider: Matched regex 'Colloquy.+\.zip' among asset(s): Colloquy_7097_with_Bouncer_103.zip
GitHubReleasesInfoProvider: Selected asset 'Colloquy_7097_with_Bouncer_103.zip' from release 'mac/2021/2.5-prerelease-7097'
{'Output': {'asset_created_at': '2021-07-03T15:57:40Z',
            'asset_url': 'https://api.github.com/repos/colloquy/colloquy/releases/assets/39675818',
            'release_notes': 'Fixes for Libera.Chat, among other things',
            'url': 'https://github.com/colloquy/colloquy/releases/download/mac/2021/2.5-prerelease-7097/Colloquy_7097_with_Bouncer_103.zip',
            'version': 'mac/2021/2.5-prerelease-7097'}}
URLDownloader
{'Input': {'url': 'https://github.com/colloquy/colloquy/releases/download/mac/2021/2.5-prerelease-7097/Colloquy_7097_with_Bouncer_103.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Tue, 07 Dec 2021 04:52:30 GMT
URLDownloader: Storing new ETag header: "0x8D9B93D5FDB9564"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.Colloquy.download/downloads/Colloquy_7097_with_Bouncer_103.zip
{'Output': {'download_changed': True,
            'etag': '"0x8D9B93D5FDB9564"',
            'last_modified': 'Tue, 07 Dec 2021 04:52:30 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.Colloquy.download/downloads/Colloquy_7097_with_Bouncer_103.zip',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.Colloquy.download/downloads/Colloquy_7097_with_Bouncer_103.zip'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.Colloquy.download/receipts/Colloquy.download-receipt-20241226-220114.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.Colloquy.download/downloads/Colloquy_7097_with_Bouncer_103.zip
```
