### PR TITLE
Deprecate Unison recipes

### DIFF
--- a/Panic/Unison.download.recipe
+++ b/Panic/Unison.download.recipe
@@ -16,6 +16,15 @@
 	<key>Process</key>
 	<array>
 		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>Unison has been discontinued (details: https://panic.com/blog/the-future-of-unison/). This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+        </dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>appcast_url</key>


### PR DESCRIPTION
Unison has been discontinued (details: https://panic.com/blog/the-future-of-unison/). This PR deprecates Unison recipes.
