### PR TITLE
Deprecate Transmit recipes

### DIFF
--- a/Panic/Transmit.download.recipe
+++ b/Panic/Transmit.download.recipe
@@ -16,6 +16,15 @@
 	<key>Process</key>
 	<array>
 		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>Consider switching to the Transmit5 recipes in the autopkg/recipes repo (https://github.com/autopkg/recipes/tree/master/Panic). This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>appcast_url</key>


### PR DESCRIPTION
This PR deprecates non-functional Transmit recipes and points users to alternatives in the autopkg/recipes repo.
