### PR TITLE
Deprecate Coda recipes

### DIFF
--- a/Panic/Coda.download.recipe
+++ b/Panic/Coda.download.recipe
@@ -16,6 +16,15 @@
 	<key>Process</key>
 	<array>
 		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>Panic has discontinued Coda in favor of Nova (details: https://panic.com/coda/). This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>appcast_url</key>

--- a/Panic/Coda2.download.recipe
+++ b/Panic/Coda2.download.recipe
@@ -16,6 +16,15 @@
 	<key>Process</key>
 	<array>
 		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>Panic has discontinued Coda in favor of Nova (details: https://panic.com/coda/). This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>appcast_url</key>


### PR DESCRIPTION
This PR deprecates Coda recipes, because Panic has discontinued Coda in favor of Nova ([details](https://panic.com/coda/)).
