### PR TITLE
Escape square brackets in StarTech USB Driver URL

### DIFF
--- a/StarTech/StarTechUSBDriver.download.recipe
+++ b/StarTech/StarTechUSBDriver.download.recipe
@@ -9,7 +9,7 @@
 	<key>Input</key>
 	<dict>
 		<key>DOWNLOAD_URL</key>
-		<string>https://sgcdn.startech.com/005329/media/sets/ax88179_Mac_Drivers/[ASIX88179]%20Mac%20USB%20Network%20Adapter.zip</string>
+		<string>https://sgcdn.startech.com/005329/media/sets/ax88179_Mac_Drivers/\[ASIX88179\]%20Mac%20USB%20Network%20Adapter.zip</string>
 		<key>NAME</key>
 		<string>StarTechUSBDriver</string>
         <key>FILENAME</key>


### PR DESCRIPTION
This PR escapes the square brackets in the StarTech driver URL, because this appears not to survive AutoPkg variable substitution otherwise.

Verbose recipe run output:

```
% autopkg run -vvq 'StarTech/StarTechUSBDriver.download.recipe'
Processing StarTech/StarTechUSBDriver.download.recipe...
WARNING: StarTech/StarTechUSBDriver.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'StarTechUSBDriver.zip',
           'url': 'https://sgcdn.startech.com/005329/media/sets/ax88179_Mac_Drivers/\\[ASIX88179\\]%20Mac%20USB%20Network%20Adapter.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Tue, 10 Oct 2023 14:14:44 GMT
URLDownloader: Storing new ETag header: "8d6f71d84fbd91:0"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.keeleysam-recipes.download.StarTechUSBDriver/downloads/StarTechUSBDriver.zip
{'Output': {'download_changed': True,
            'etag': '"8d6f71d84fbd91:0"',
            'last_modified': 'Tue, 10 Oct 2023 14:14:44 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.keeleysam-recipes.download.StarTechUSBDriver/downloads/StarTechUSBDriver.zip',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.keeleysam-recipes.download.StarTechUSBDriver/downloads/StarTechUSBDriver.zip'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.keeleysam-recipes.download.StarTechUSBDriver/downloads/StarTechUSBDriver.zip'}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'zip' from filename StarTechUSBDriver.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.keeleysam-recipes.download.StarTechUSBDriver/downloads/StarTechUSBDriver.zip to ~/Library/AutoPkg/Cache/com.github.keeleysam-recipes.download.StarTechUSBDriver/StarTechUSBDriver
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.keeleysam-recipes.download.StarTechUSBDriver/receipts/StarTechUSBDriver.download-receipt-20241226-214532.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.keeleysam-recipes.download.StarTechUSBDriver/downloads/StarTechUSBDriver.zip
```
