### PR TITLE
Deprecate Mailplane 3 recipes

### DIFF
--- a/Mailplane/Mailplane3.download.recipe
+++ b/Mailplane/Mailplane3.download.recipe
@@ -14,9 +14,18 @@
 		<string>https://update.mailplaneapp.com/appcast.php?appName=Mailplane%203</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.1</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>Consider switching to the Mailplane 4 recipes in the jannheider-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>


### PR DESCRIPTION
Mailplane 3 is no longer available for download. This PR deprecates the Mailplane 3 recipes and points users to the Mailplane 4 recipes in the jannheider-recipes repo.
