### PR TITLE
Deprecate Caffeine recipes

### DIFF
--- a/Caffeine/Caffeine.download.recipe
+++ b/Caffeine/Caffeine.download.recipe
@@ -23,6 +23,15 @@ For the OS_VERSION_DOWNLOAD variable please use:
     <key>Process</key>
     <array>
         <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the Caffeine recipes in the peetinc-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
+        <dict>
             <key>Arguments</key>
             <dict>
                 <key>filename</key>


### PR DESCRIPTION
For the sake of simplifying search results in the AutoPkg org, this PR deprecates the Caffeine recipes in this repo in favor of the similar recipes in peetinc-recipes. It may be a point of minor confusion to users that there is no `OS_VERSION_DOWNLOAD` option for `sequoia` at this time, but the Sparkle feed used by the peetinc-recipes version requires no such consideration.
