### PR TITLE
Rework FileZilla recipes and fix nightly build download

### DIFF
--- a/FileZilla/FileZilla.download.recipe
+++ b/FileZilla/FileZilla.download.recipe
@@ -3,18 +3,26 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the current version of FileZilla. Specify the channel via %NAME%.</string>
+	<string>Downloads the latest stable version of FileZilla for Mac.
+	
+Valid values for ARCH include:
+- "x86" (default, Intel)
+- "arm64" (Apple Silicon)
+Note the architecture values are not the same as the FileZilla nightly recipe.
+</string>
 	<key>Identifier</key>
 	<string>com.github.keeleysam.recipes.FileZilla.download</string>
 	<key>Input</key>
 	<dict>
 		<key>NAME</key>
 		<string>FileZilla</string>
+		<key>ARCH</key>
+		<string>x86</string>
 		<key>RE_PATTERN</key>
-		<string>&lt;a href=\"(?P&lt;url&gt;http[s]?.*?(?P&lt;filename&gt;FileZilla_(?P&lt;version&gt;[\d.]+)_macos-x86.*?\.tar\.bz2).*?)\"</string>
+		<string>&lt;a href=\"(?P&lt;url&gt;http[s]?.*?(?P&lt;filename&gt;FileZilla_(?P&lt;version&gt;[\d.]+)_macos-%ARCH%.*?\.tar\.bz2).*?)\"</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>1.0.0</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/FileZilla/FileZilla_beta.munki.recipe
+++ b/FileZilla/FileZilla_beta.munki.recipe
@@ -27,11 +27,20 @@
 		</dict>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.0</string>
+	<string>1.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.keeleysam.recipes.FileZilla.download</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>As of December 2024, FileZilla betas are not available for download. Consider switching to the FileZilla_nightly recipes in this repo. This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>

--- a/FileZilla/FileZilla_nightly.download.recipe
+++ b/FileZilla/FileZilla_nightly.download.recipe
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Downloads the most recent nightly build of FileZilla for Mac.
+	
+Valid values for ARCH include:
+- "x86_64" (default, Intel)
+- "aarch64" (Apple Silicon)
+Note the architecture values are not the same as the FileZilla stable recipe.
+</string>
+	<key>Identifier</key>
+	<string>com.github.keeleysam.recipes.FileZilla.nightly.download</string>
+	<key>Input</key>
+	<dict>
+		<key>NAME</key>
+		<string>FileZilla_nightly</string>
+		<key>ARCH</key>
+		<string>x86_64</string>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>1.1</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>re_pattern</key>
+				<string>href="(/nightlies/[\d-]+/%ARCH%-apple-darwin[\d\.]+/FileZilla\d+\.app\.tar\.bz2)"</string>
+				<key>url</key>
+				<string>https://filezilla-project.org/nightly.php</string>
+			</dict>
+			<key>Processor</key>
+			<string>URLTextSearcher</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>url</key>
+				<string>https://filezilla-project.org/%match%</string>
+				<key>filename</key>
+				<string>%NAME%.tar.bz2</string>
+			</dict>
+			<key>Processor</key>
+			<string>URLDownloader</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>Unarchiver</string>
+			<key>Arguments</key>
+			<dict>
+				<key>purge_destination</key>
+				<true/>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
+			<key>Arguments</key>
+			<dict>
+				<key>input_path</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/FileZilla.app</string>
+				<key>requirement</key>
+				<string>identifier "org.filezilla-project.filezilla" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "5VPGKXL75N"</string>
+			</dict>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/FileZilla/FileZilla_nightly.munki.recipe
+++ b/FileZilla/FileZilla_nightly.munki.recipe
@@ -29,7 +29,7 @@
 	<key>MinimumVersion</key>
 	<string>0.2.0</string>
 	<key>ParentRecipe</key>
-	<string>com.github.keeleysam.recipes.FileZilla.download</string>
+	<string>com.github.keeleysam.recipes.FileZilla.nightly.download</string>
 	<key>Process</key>
 	<array>
 		<dict>


### PR DESCRIPTION
This PR updates the FileZilla recipes as follows.

- The **beta** recipes are deprecated, as there are no beta downloads available on the FileZilla project website currently.
- The **nightly** recipes were not working, instead downloading the regular stable version of FileZilla. A new nightly download recipe has been created specifically for downloading nightly builds, and the nightly munki recipe parent has been changed to the new download recipe. An ARCH input variable is included for conveinent specification of Intel or Apple Silicon nightly download.
- The **stable** recipe has been updated to make its support for multiple architecture downloads more explicit by adding an ARCH input variable that is used in the regex pattern.

With this PR, I'm setting up your FileZilla download recipe to be the recommended one in the AutoPkg org, and deprecating similar recipes in other repos. If that feels like more maintenance than it's worth to you, let me know and we can arrange for somebody else to be the FileZilla torch-bearer.

Thank you!

---

Verbose download/munki recipe run output for FileZilla (stable, Intel):

```
% autopkg run -vvq FileZilla.{download,munki}.recipe
Processing FileZilla.download.recipe...
WARNING: FileZilla.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': '<a '
                         'href=\\"(?P<url>http[s]?.*?(?P<filename>FileZilla_(?P<version>[\\d.]+)_macos-x86.*?\\.tar\\.bz2).*?)\\"',
           'request_headers': {'user-agent': 'Mozilla/5.0 (Macintosh; Intel '
                                             'Mac OS X 10_15_4) '
                                             'AppleWebKit/605.1.15 (KHTML, '
                                             'like Gecko) Version/13.1 '
                                             'Safari/605.1.15'},
           'url': 'https://filezilla-project.org/download.php?show_all=1'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (url): https://dl2.cdn.filezilla-project.org/client/FileZilla_3.68.1_macos-x86.app.tar.bz2?h=78wxf52uj1iqNXkPRgmoZQ&x=1735598594
URLTextSearcher: Found matching text (filename): FileZilla_3.68.1_macos-x86.app.tar.bz2
URLTextSearcher: Found matching text (version): 3.68.1
URLTextSearcher: Found matching text (match): https://dl2.cdn.filezilla-project.org/client/FileZilla_3.68.1_macos-x86.app.tar.bz2?h=78wxf52uj1iqNXkPRgmoZQ&x=1735598594
{'Output': {'filename': 'FileZilla_3.68.1_macos-x86.app.tar.bz2',
            'match': 'https://dl2.cdn.filezilla-project.org/client/FileZilla_3.68.1_macos-x86.app.tar.bz2?h=78wxf52uj1iqNXkPRgmoZQ&x=1735598594',
            'url': 'https://dl2.cdn.filezilla-project.org/client/FileZilla_3.68.1_macos-x86.app.tar.bz2?h=78wxf52uj1iqNXkPRgmoZQ&x=1735598594',
            'version': '3.68.1'}}
URLDownloader
{'Input': {'filename': 'FileZilla_3.68.1_macos-x86.app.tar.bz2',
           'request_headers': {'user-agent': 'Mozilla/5.0 (Macintosh; Intel '
                                             'Mac OS X 10_15_4) '
                                             'AppleWebKit/605.1.15 (KHTML, '
                                             'like Gecko) Version/13.1 '
                                             'Safari/605.1.15'},
           'url': 'https://dl2.cdn.filezilla-project.org/client/FileZilla_3.68.1_macos-x86.app.tar.bz2?h=78wxf52uj1iqNXkPRgmoZQ&x=1735598594'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.download/downloads/FileZilla_3.68.1_macos-x86.app.tar.bz2
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.download/downloads/FileZilla_3.68.1_macos-x86.app.tar.bz2'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'purge_destination': True}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'tar_bzip2' from filename FileZilla_3.68.1_macos-x86.app.tar.bz2
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.download/downloads/FileZilla_3.68.1_macos-x86.app.tar.bz2 to ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.download/FileZilla
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.download/FileZilla/FileZilla.app',
           'requirement': 'identifier "org.filezilla-project.filezilla" and '
                          'anchor apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"5VPGKXL75N"'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.download/FileZilla/FileZilla.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.download/FileZilla/FileZilla.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.download/FileZilla/FileZilla.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.download/receipts/FileZilla.download-receipt-20241230-134316.plist
Processing FileZilla.munki.recipe...
WARNING: FileZilla.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': '<a '
                         'href=\\"(?P<url>http[s]?.*?(?P<filename>FileZilla_(?P<version>[\\d.]+)_macos-x86.*?\\.tar\\.bz2).*?)\\"',
           'request_headers': {'user-agent': 'Mozilla/5.0 (Macintosh; Intel '
                                             'Mac OS X 10_15_4) '
                                             'AppleWebKit/605.1.15 (KHTML, '
                                             'like Gecko) Version/13.1 '
                                             'Safari/605.1.15'},
           'url': 'https://filezilla-project.org/download.php?show_all=1'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (url): https://dl4.cdn.filezilla-project.org/client/FileZilla_3.68.1_macos-x86.app.tar.bz2?h=MniwfDswXdfn90B899ERvg&x=1735598597
URLTextSearcher: Found matching text (filename): FileZilla_3.68.1_macos-x86.app.tar.bz2
URLTextSearcher: Found matching text (version): 3.68.1
URLTextSearcher: Found matching text (match): https://dl4.cdn.filezilla-project.org/client/FileZilla_3.68.1_macos-x86.app.tar.bz2?h=MniwfDswXdfn90B899ERvg&x=1735598597
{'Output': {'filename': 'FileZilla_3.68.1_macos-x86.app.tar.bz2',
            'match': 'https://dl4.cdn.filezilla-project.org/client/FileZilla_3.68.1_macos-x86.app.tar.bz2?h=MniwfDswXdfn90B899ERvg&x=1735598597',
            'url': 'https://dl4.cdn.filezilla-project.org/client/FileZilla_3.68.1_macos-x86.app.tar.bz2?h=MniwfDswXdfn90B899ERvg&x=1735598597',
            'version': '3.68.1'}}
URLDownloader
{'Input': {'filename': 'FileZilla_3.68.1_macos-x86.app.tar.bz2',
           'request_headers': {'user-agent': 'Mozilla/5.0 (Macintosh; Intel '
                                             'Mac OS X 10_15_4) '
                                             'AppleWebKit/605.1.15 (KHTML, '
                                             'like Gecko) Version/13.1 '
                                             'Safari/605.1.15'},
           'url': 'https://dl4.cdn.filezilla-project.org/client/FileZilla_3.68.1_macos-x86.app.tar.bz2?h=MniwfDswXdfn90B899ERvg&x=1735598597'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Mon, 04 Nov 2024 15:50:57 GMT
URLDownloader: Storing new ETag header: "6728ed61-ed2cdb"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.munki/downloads/FileZilla_3.68.1_macos-x86.app.tar.bz2
{'Output': {'download_changed': True,
            'etag': '"6728ed61-ed2cdb"',
            'last_modified': 'Mon, 04 Nov 2024 15:50:57 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.munki/downloads/FileZilla_3.68.1_macos-x86.app.tar.bz2',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.munki/downloads/FileZilla_3.68.1_macos-x86.app.tar.bz2'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'purge_destination': True}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'tar_bzip2' from filename FileZilla_3.68.1_macos-x86.app.tar.bz2
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.munki/downloads/FileZilla_3.68.1_macos-x86.app.tar.bz2 to ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.munki/FileZilla
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.munki/FileZilla/FileZilla.app',
           'requirement': 'identifier "org.filezilla-project.filezilla" and '
                          'anchor apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"5VPGKXL75N"'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.munki/FileZilla/FileZilla.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.munki/FileZilla/FileZilla.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.munki/FileZilla/FileZilla.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
DmgCreator
{'Input': {'dmg_path': '~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.munki/FileZilla.dmg',
           'dmg_root': '~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.munki/FileZilla'}}
DmgCreator: Created dmg from ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.munki/FileZilla at ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.munki/FileZilla.dmg
{'Output': {}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/Users/Shared/munki_repo',
           'pkg_path': '~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.munki/FileZilla.dmg',
           'pkginfo': {'catalogs': ['testing'],
                       'description': 'FileZilla is a fast and reliable '
                                      'cross-platform FTP, FTPS and SFTP '
                                      'client.',
                       'display_name': 'FileZilla',
                       'name': 'FileZilla',
                       'unattended_install': True},
           'repo_subdirectory': 'apps/FileZilla'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/FileZilla/FileZilla-3.68.1.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/FileZilla/FileZilla-3.68.1.dmg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': 'testing',
                                                       'icon_repo_path': '',
                                                       'name': 'FileZilla',
                                                       'pkg_repo_path': 'apps/FileZilla/FileZilla-3.68.1.dmg',
                                                       'pkginfo_path': 'apps/FileZilla/FileZilla-3.68.1.plist',
                                                       'version': '3.68.1'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path',
                                                                'icon_repo_path'],
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'imported into '
                                                              'Munki:'},
            'munki_info': {'_metadata': {'created_by': 'testuser',
                                         'creation_date': datetime.datetime(2024, 12, 30, 21, 43, 27),
                                         'munki_version': '6.6.3.4704',
                                         'os_version': '15.2'},
                           'autoremove': False,
                           'catalogs': ['testing'],
                           'description': 'FileZilla is a fast and reliable '
                                          'cross-platform FTP, FTPS and SFTP '
                                          'client.',
                           'display_name': 'FileZilla',
                           'installer_item_hash': '9d0a1d5ad41028dec7b3a073a03fa5a2755e1dc9dc1c992d133a19d48ca83465',
                           'installer_item_location': 'apps/FileZilla/FileZilla-3.68.1.dmg',
                           'installer_item_size': 18343,
                           'installer_type': 'copy_from_dmg',
                           'installs': [{'CFBundleIdentifier': 'org.filezilla-project.filezilla',
                                         'CFBundleName': 'FileZilla',
                                         'CFBundleShortVersionString': '3.68.1',
                                         'CFBundleVersion': '3.68.1',
                                         'minosversion': '10.13.2',
                                         'path': '/Applications/FileZilla.app',
                                         'type': 'application',
                                         'version_comparison_key': 'CFBundleShortVersionString'}],
                           'items_to_copy': [{'destination_path': '/Applications',
                                              'source_item': 'FileZilla.app'}],
                           'minimum_os_version': '10.13.2',
                           'name': 'FileZilla',
                           'unattended_install': True,
                           'uninstall_method': 'remove_copied_items',
                           'uninstallable': True,
                           'version': '3.68.1'},
            'munki_repo_changed': True,
            'pkg_repo_path': '/Users/Shared/munki_repo/pkgs/apps/FileZilla/FileZilla-3.68.1.dmg',
            'pkginfo_repo_path': '/Users/Shared/munki_repo/pkgsinfo/apps/FileZilla/FileZilla-3.68.1.plist'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.munki/receipts/FileZilla.munki-receipt-20241230-134327.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.munki/downloads/FileZilla_3.68.1_macos-x86.app.tar.bz2

The following new items were imported into Munki:
    Name       Version  Catalogs  Pkginfo Path                           Pkg Repo Path                        Icon Repo Path
    ----       -------  --------  ------------                           -------------                        --------------
    FileZilla  3.68.1   testing   apps/FileZilla/FileZilla-3.68.1.plist  apps/FileZilla/FileZilla-3.68.1.dmg
```

Verbose download/munki recipe run output for FileZilla (stable, Apple Silicon):

```
% autopkg run -vvq FileZilla.{download,munki}.recipe -k ARCH=arm64
Processing FileZilla.download.recipe...
WARNING: FileZilla.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': '<a '
                         'href=\\"(?P<url>http[s]?.*?(?P<filename>FileZilla_(?P<version>[\\d.]+)_macos-arm64.*?\\.tar\\.bz2).*?)\\"',
           'request_headers': {'user-agent': 'Mozilla/5.0 (Macintosh; Intel '
                                             'Mac OS X 10_15_4) '
                                             'AppleWebKit/605.1.15 (KHTML, '
                                             'like Gecko) Version/13.1 '
                                             'Safari/605.1.15'},
           'url': 'https://filezilla-project.org/download.php?show_all=1'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (url): https://dl3.cdn.filezilla-project.org/client/FileZilla_3.68.1_macos-arm64.app.tar.bz2?h=LtyMqOLZ2EZEzmEGemFk-A&x=1735598615
URLTextSearcher: Found matching text (filename): FileZilla_3.68.1_macos-arm64.app.tar.bz2
URLTextSearcher: Found matching text (version): 3.68.1
URLTextSearcher: Found matching text (match): https://dl3.cdn.filezilla-project.org/client/FileZilla_3.68.1_macos-arm64.app.tar.bz2?h=LtyMqOLZ2EZEzmEGemFk-A&x=1735598615
{'Output': {'filename': 'FileZilla_3.68.1_macos-arm64.app.tar.bz2',
            'match': 'https://dl3.cdn.filezilla-project.org/client/FileZilla_3.68.1_macos-arm64.app.tar.bz2?h=LtyMqOLZ2EZEzmEGemFk-A&x=1735598615',
            'url': 'https://dl3.cdn.filezilla-project.org/client/FileZilla_3.68.1_macos-arm64.app.tar.bz2?h=LtyMqOLZ2EZEzmEGemFk-A&x=1735598615',
            'version': '3.68.1'}}
URLDownloader
{'Input': {'filename': 'FileZilla_3.68.1_macos-arm64.app.tar.bz2',
           'request_headers': {'user-agent': 'Mozilla/5.0 (Macintosh; Intel '
                                             'Mac OS X 10_15_4) '
                                             'AppleWebKit/605.1.15 (KHTML, '
                                             'like Gecko) Version/13.1 '
                                             'Safari/605.1.15'},
           'url': 'https://dl3.cdn.filezilla-project.org/client/FileZilla_3.68.1_macos-arm64.app.tar.bz2?h=LtyMqOLZ2EZEzmEGemFk-A&x=1735598615'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Mon, 04 Nov 2024 15:50:56 GMT
URLDownloader: Storing new ETag header: "6728ed60-d3eef1"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.download/downloads/FileZilla_3.68.1_macos-arm64.app.tar.bz2
{'Output': {'download_changed': True,
            'etag': '"6728ed60-d3eef1"',
            'last_modified': 'Mon, 04 Nov 2024 15:50:56 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.download/downloads/FileZilla_3.68.1_macos-arm64.app.tar.bz2',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.download/downloads/FileZilla_3.68.1_macos-arm64.app.tar.bz2'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'purge_destination': True}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'tar_bzip2' from filename FileZilla_3.68.1_macos-arm64.app.tar.bz2
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.download/downloads/FileZilla_3.68.1_macos-arm64.app.tar.bz2 to ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.download/FileZilla
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.download/FileZilla/FileZilla.app',
           'requirement': 'identifier "org.filezilla-project.filezilla" and '
                          'anchor apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"5VPGKXL75N"'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.download/FileZilla/FileZilla.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.download/FileZilla/FileZilla.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.download/FileZilla/FileZilla.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.download/receipts/FileZilla.download-receipt-20241230-134339.plist
Processing FileZilla.munki.recipe...
WARNING: FileZilla.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': '<a '
                         'href=\\"(?P<url>http[s]?.*?(?P<filename>FileZilla_(?P<version>[\\d.]+)_macos-x86.*?\\.tar\\.bz2).*?)\\"',
           'request_headers': {'user-agent': 'Mozilla/5.0 (Macintosh; Intel '
                                             'Mac OS X 10_15_4) '
                                             'AppleWebKit/605.1.15 (KHTML, '
                                             'like Gecko) Version/13.1 '
                                             'Safari/605.1.15'},
           'url': 'https://filezilla-project.org/download.php?show_all=1'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (url): https://dl3.cdn.filezilla-project.org/client/FileZilla_3.68.1_macos-x86.app.tar.bz2?h=syZly7BOcc3eZHXk6rHK0g&x=1735598619
URLTextSearcher: Found matching text (filename): FileZilla_3.68.1_macos-x86.app.tar.bz2
URLTextSearcher: Found matching text (version): 3.68.1
URLTextSearcher: Found matching text (match): https://dl3.cdn.filezilla-project.org/client/FileZilla_3.68.1_macos-x86.app.tar.bz2?h=syZly7BOcc3eZHXk6rHK0g&x=1735598619
{'Output': {'filename': 'FileZilla_3.68.1_macos-x86.app.tar.bz2',
            'match': 'https://dl3.cdn.filezilla-project.org/client/FileZilla_3.68.1_macos-x86.app.tar.bz2?h=syZly7BOcc3eZHXk6rHK0g&x=1735598619',
            'url': 'https://dl3.cdn.filezilla-project.org/client/FileZilla_3.68.1_macos-x86.app.tar.bz2?h=syZly7BOcc3eZHXk6rHK0g&x=1735598619',
            'version': '3.68.1'}}
URLDownloader
{'Input': {'filename': 'FileZilla_3.68.1_macos-x86.app.tar.bz2',
           'request_headers': {'user-agent': 'Mozilla/5.0 (Macintosh; Intel '
                                             'Mac OS X 10_15_4) '
                                             'AppleWebKit/605.1.15 (KHTML, '
                                             'like Gecko) Version/13.1 '
                                             'Safari/605.1.15'},
           'url': 'https://dl3.cdn.filezilla-project.org/client/FileZilla_3.68.1_macos-x86.app.tar.bz2?h=syZly7BOcc3eZHXk6rHK0g&x=1735598619'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.munki/downloads/FileZilla_3.68.1_macos-x86.app.tar.bz2
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.munki/downloads/FileZilla_3.68.1_macos-x86.app.tar.bz2'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'purge_destination': True}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'tar_bzip2' from filename FileZilla_3.68.1_macos-x86.app.tar.bz2
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.munki/downloads/FileZilla_3.68.1_macos-x86.app.tar.bz2 to ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.munki/FileZilla
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.munki/FileZilla/FileZilla.app',
           'requirement': 'identifier "org.filezilla-project.filezilla" and '
                          'anchor apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"5VPGKXL75N"'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.munki/FileZilla/FileZilla.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.munki/FileZilla/FileZilla.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.munki/FileZilla/FileZilla.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
DmgCreator
{'Input': {'dmg_path': '~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.munki/FileZilla.dmg',
           'dmg_root': '~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.munki/FileZilla'}}
DmgCreator: Created dmg from ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.munki/FileZilla at ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.munki/FileZilla.dmg
{'Output': {}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/Users/Shared/munki_repo',
           'pkg_path': '~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.munki/FileZilla.dmg',
           'pkginfo': {'catalogs': ['testing'],
                       'description': 'FileZilla is a fast and reliable '
                                      'cross-platform FTP, FTPS and SFTP '
                                      'client.',
                       'display_name': 'FileZilla',
                       'name': 'FileZilla',
                       'unattended_install': True},
           'repo_subdirectory': 'apps/FileZilla'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/FileZilla/FileZilla-3.68.1__1.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/FileZilla/FileZilla-3.68.1__1.dmg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': 'testing',
                                                       'icon_repo_path': '',
                                                       'name': 'FileZilla',
                                                       'pkg_repo_path': 'apps/FileZilla/FileZilla-3.68.1__1.dmg',
                                                       'pkginfo_path': 'apps/FileZilla/FileZilla-3.68.1__1.plist',
                                                       'version': '3.68.1'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path',
                                                                'icon_repo_path'],
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'imported into '
                                                              'Munki:'},
            'munki_info': {'_metadata': {'created_by': 'testuser',
                                         'creation_date': datetime.datetime(2024, 12, 30, 21, 43, 48),
                                         'munki_version': '6.6.3.4704',
                                         'os_version': '15.2'},
                           'autoremove': False,
                           'catalogs': ['testing'],
                           'description': 'FileZilla is a fast and reliable '
                                          'cross-platform FTP, FTPS and SFTP '
                                          'client.',
                           'display_name': 'FileZilla',
                           'installer_item_hash': '4708dcdf141c9a1ec4b4cabeba24ef416f5f4370de015340aeba3172e0ceecba',
                           'installer_item_location': 'apps/FileZilla/FileZilla-3.68.1__1.dmg',
                           'installer_item_size': 18340,
                           'installer_type': 'copy_from_dmg',
                           'installs': [{'CFBundleIdentifier': 'org.filezilla-project.filezilla',
                                         'CFBundleName': 'FileZilla',
                                         'CFBundleShortVersionString': '3.68.1',
                                         'CFBundleVersion': '3.68.1',
                                         'minosversion': '10.13.2',
                                         'path': '/Applications/FileZilla.app',
                                         'type': 'application',
                                         'version_comparison_key': 'CFBundleShortVersionString'}],
                           'items_to_copy': [{'destination_path': '/Applications',
                                              'source_item': 'FileZilla.app'}],
                           'minimum_os_version': '10.13.2',
                           'name': 'FileZilla',
                           'unattended_install': True,
                           'uninstall_method': 'remove_copied_items',
                           'uninstallable': True,
                           'version': '3.68.1'},
            'munki_repo_changed': True,
            'pkg_repo_path': '/Users/Shared/munki_repo/pkgs/apps/FileZilla/FileZilla-3.68.1__1.dmg',
            'pkginfo_repo_path': '/Users/Shared/munki_repo/pkgsinfo/apps/FileZilla/FileZilla-3.68.1__1.plist'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.munki/receipts/FileZilla.munki-receipt-20241230-134348.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.download/downloads/FileZilla_3.68.1_macos-arm64.app.tar.bz2

The following new items were imported into Munki:
    Name       Version  Catalogs  Pkginfo Path                              Pkg Repo Path                           Icon Repo Path
    ----       -------  --------  ------------                              -------------                           --------------
    FileZilla  3.68.1   testing   apps/FileZilla/FileZilla-3.68.1__1.plist  apps/FileZilla/FileZilla-3.68.1__1.dmg
```

Verbose download/munki recipe run output for FileZilla (nightly, Intel):

```
% autopkg run -vvq FileZilla_nightly.{download,munki}.recipe
Processing FileZilla_nightly.download.recipe...
WARNING: FileZilla_nightly.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'href="(/nightlies/[\\d-]+/x86_64-apple-darwin[\\d\\.]+/FileZilla\\d+\\.app\\.tar\\.bz2)"',
           'url': 'https://filezilla-project.org/nightly.php'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (match): /nightlies/2024-12-21/x86_64-apple-darwin18.2.0/FileZilla3.app.tar.bz2
{'Output': {'match': '/nightlies/2024-12-21/x86_64-apple-darwin18.2.0/FileZilla3.app.tar.bz2'}}
URLDownloader
{'Input': {'filename': 'FileZilla_nightly.tar.bz2',
           'url': 'https://filezilla-project.org//nightlies/2024-12-21/x86_64-apple-darwin18.2.0/FileZilla3.app.tar.bz2'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.nightly.download/downloads/FileZilla_nightly.tar.bz2
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.nightly.download/downloads/FileZilla_nightly.tar.bz2'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'purge_destination': True}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'tar_bzip2' from filename FileZilla_nightly.tar.bz2
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.nightly.download/downloads/FileZilla_nightly.tar.bz2 to ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.nightly.download/FileZilla_nightly
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.nightly.download/FileZilla_nightly/FileZilla.app',
           'requirement': 'identifier "org.filezilla-project.filezilla" and '
                          'anchor apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"5VPGKXL75N"'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.nightly.download/FileZilla_nightly/FileZilla.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.nightly.download/FileZilla_nightly/FileZilla.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.nightly.download/FileZilla_nightly/FileZilla.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.nightly.download/receipts/FileZilla_nightly.download-receipt-20241230-134420.plist
Processing FileZilla_nightly.munki.recipe...
WARNING: FileZilla_nightly.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'href="(/nightlies/[\\d-]+/x86_64-apple-darwin[\\d\\.]+/FileZilla\\d+\\.app\\.tar\\.bz2)"',
           'url': 'https://filezilla-project.org/nightly.php'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (match): /nightlies/2024-12-21/x86_64-apple-darwin18.2.0/FileZilla3.app.tar.bz2
{'Output': {'match': '/nightlies/2024-12-21/x86_64-apple-darwin18.2.0/FileZilla3.app.tar.bz2'}}
URLDownloader
{'Input': {'filename': 'FileZilla_nightly.tar.bz2',
           'url': 'https://filezilla-project.org//nightlies/2024-12-21/x86_64-apple-darwin18.2.0/FileZilla3.app.tar.bz2'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Sat, 21 Dec 2024 04:40:26 GMT
URLDownloader: Storing new ETag header: "eb3cfb-629c05cbf600d"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.nightly.munki/downloads/FileZilla_nightly.tar.bz2
{'Output': {'download_changed': True,
            'etag': '"eb3cfb-629c05cbf600d"',
            'last_modified': 'Sat, 21 Dec 2024 04:40:26 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.nightly.munki/downloads/FileZilla_nightly.tar.bz2',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.nightly.munki/downloads/FileZilla_nightly.tar.bz2'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'purge_destination': True}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'tar_bzip2' from filename FileZilla_nightly.tar.bz2
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.nightly.munki/downloads/FileZilla_nightly.tar.bz2 to ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.nightly.munki/FileZilla_nightly
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.nightly.munki/FileZilla_nightly/FileZilla.app',
           'requirement': 'identifier "org.filezilla-project.filezilla" and '
                          'anchor apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"5VPGKXL75N"'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.nightly.munki/FileZilla_nightly/FileZilla.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.nightly.munki/FileZilla_nightly/FileZilla.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.nightly.munki/FileZilla_nightly/FileZilla.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Unarchiver
{'Input': {'USE_PYTHON_NATIVE_EXTRACTOR': False,
           'archive_path': '~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.nightly.munki/downloads/FileZilla_nightly.tar.bz2',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.nightly.munki/FileZilla_nightly',
           'purge_destination': True}}
Unarchiver: Guessed archive format 'tar_bzip2' from filename FileZilla_nightly.tar.bz2
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.nightly.munki/downloads/FileZilla_nightly.tar.bz2 to ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.nightly.munki/FileZilla_nightly
{'Output': {}}
DmgCreator
{'Input': {'dmg_path': '~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.nightly.munki/FileZilla_nightly.dmg',
           'dmg_root': '~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.nightly.munki/FileZilla_nightly'}}
DmgCreator: Created dmg from ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.nightly.munki/FileZilla_nightly at ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.nightly.munki/FileZilla_nightly.dmg
{'Output': {}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/Users/Shared/munki_repo',
           'pkg_path': '~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.nightly.munki/FileZilla_nightly.dmg',
           'pkginfo': {'catalogs': ['testing'],
                       'display_name': 'FileZilla',
                       'name': 'FileZilla_nightly',
                       'unattended_install': True},
           'repo_subdirectory': 'apps/FileZilla/nightly'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/FileZilla/nightly/FileZilla_nightly-3.68.1.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/FileZilla/nightly/FileZilla_nightly-3.68.1.dmg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': 'testing',
                                                       'icon_repo_path': '',
                                                       'name': 'FileZilla_nightly',
                                                       'pkg_repo_path': 'apps/FileZilla/nightly/FileZilla_nightly-3.68.1.dmg',
                                                       'pkginfo_path': 'apps/FileZilla/nightly/FileZilla_nightly-3.68.1.plist',
                                                       'version': '3.68.1'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path',
                                                                'icon_repo_path'],
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'imported into '
                                                              'Munki:'},
            'munki_info': {'_metadata': {'created_by': 'testuser',
                                         'creation_date': datetime.datetime(2024, 12, 30, 21, 44, 32),
                                         'munki_version': '6.6.3.4704',
                                         'os_version': '15.2'},
                           'autoremove': False,
                           'catalogs': ['testing'],
                           'display_name': 'FileZilla',
                           'installer_item_hash': '98220ee4baf3365cd147baaafd2bb3222f0dac7176536cf5b64e1250f71646bb',
                           'installer_item_location': 'apps/FileZilla/nightly/FileZilla_nightly-3.68.1.dmg',
                           'installer_item_size': 17778,
                           'installer_type': 'copy_from_dmg',
                           'installs': [{'CFBundleIdentifier': 'org.filezilla-project.filezilla',
                                         'CFBundleName': 'FileZilla',
                                         'CFBundleShortVersionString': '3.68.1',
                                         'CFBundleVersion': '3.68.1',
                                         'minosversion': '10.13.2',
                                         'path': '/Applications/FileZilla.app',
                                         'type': 'application',
                                         'version_comparison_key': 'CFBundleShortVersionString'}],
                           'items_to_copy': [{'destination_path': '/Applications',
                                              'source_item': 'FileZilla.app'}],
                           'minimum_os_version': '10.13.2',
                           'name': 'FileZilla_nightly',
                           'unattended_install': True,
                           'uninstall_method': 'remove_copied_items',
                           'uninstallable': True,
                           'version': '3.68.1'},
            'munki_repo_changed': True,
            'pkg_repo_path': '/Users/Shared/munki_repo/pkgs/apps/FileZilla/nightly/FileZilla_nightly-3.68.1.dmg',
            'pkginfo_repo_path': '/Users/Shared/munki_repo/pkgsinfo/apps/FileZilla/nightly/FileZilla_nightly-3.68.1.plist'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.nightly.munki/receipts/FileZilla_nightly.munki-receipt-20241230-134432.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.nightly.munki/downloads/FileZilla_nightly.tar.bz2

The following new items were imported into Munki:
    Name               Version  Catalogs  Pkginfo Path                                           Pkg Repo Path                                        Icon Repo Path
    ----               -------  --------  ------------                                           -------------                                        --------------
    FileZilla_nightly  3.68.1   testing   apps/FileZilla/nightly/FileZilla_nightly-3.68.1.plist  apps/FileZilla/nightly/FileZilla_nightly-3.68.1.dmg
```

Verbose download/munki recipe run output for FileZilla (nightly, Apple Silicon):

```
% autopkg run -vvq FileZilla_nightly.{download,munki}.recipe -k ARCH=aarch64
Processing FileZilla_nightly.download.recipe...
WARNING: FileZilla_nightly.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'href="(/nightlies/[\\d-]+/aarch64-apple-darwin[\\d\\.]+/FileZilla\\d+\\.app\\.tar\\.bz2)"',
           'url': 'https://filezilla-project.org/nightly.php'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (match): /nightlies/2024-12-21/aarch64-apple-darwin23.1.0/FileZilla3.app.tar.bz2
{'Output': {'match': '/nightlies/2024-12-21/aarch64-apple-darwin23.1.0/FileZilla3.app.tar.bz2'}}
URLDownloader
{'Input': {'filename': 'FileZilla_nightly.tar.bz2',
           'url': 'https://filezilla-project.org//nightlies/2024-12-21/aarch64-apple-darwin23.1.0/FileZilla3.app.tar.bz2'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Sat, 21 Dec 2024 04:35:02 GMT
URLDownloader: Storing new ETag header: "d3ed07-629c049686495"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.nightly.download/downloads/FileZilla_nightly.tar.bz2
{'Output': {'download_changed': True,
            'etag': '"d3ed07-629c049686495"',
            'last_modified': 'Sat, 21 Dec 2024 04:35:02 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.nightly.download/downloads/FileZilla_nightly.tar.bz2',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.nightly.download/downloads/FileZilla_nightly.tar.bz2'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'purge_destination': True}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'tar_bzip2' from filename FileZilla_nightly.tar.bz2
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.nightly.download/downloads/FileZilla_nightly.tar.bz2 to ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.nightly.download/FileZilla_nightly
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.nightly.download/FileZilla_nightly/FileZilla.app',
           'requirement': 'identifier "org.filezilla-project.filezilla" and '
                          'anchor apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"5VPGKXL75N"'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.nightly.download/FileZilla_nightly/FileZilla.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.nightly.download/FileZilla_nightly/FileZilla.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.nightly.download/FileZilla_nightly/FileZilla.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.nightly.download/receipts/FileZilla_nightly.download-receipt-20241230-134454.plist
Processing FileZilla_nightly.munki.recipe...
WARNING: FileZilla_nightly.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'href="(/nightlies/[\\d-]+/aarch64-apple-darwin[\\d\\.]+/FileZilla\\d+\\.app\\.tar\\.bz2)"',
           'url': 'https://filezilla-project.org/nightly.php'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (match): /nightlies/2024-12-21/aarch64-apple-darwin23.1.0/FileZilla3.app.tar.bz2
{'Output': {'match': '/nightlies/2024-12-21/aarch64-apple-darwin23.1.0/FileZilla3.app.tar.bz2'}}
URLDownloader
{'Input': {'filename': 'FileZilla_nightly.tar.bz2',
           'url': 'https://filezilla-project.org//nightlies/2024-12-21/aarch64-apple-darwin23.1.0/FileZilla3.app.tar.bz2'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Sat, 21 Dec 2024 04:35:02 GMT
URLDownloader: Storing new ETag header: "d3ed07-629c049686495"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.nightly.munki/downloads/FileZilla_nightly.tar.bz2
{'Output': {'download_changed': True,
            'etag': '"d3ed07-629c049686495"',
            'last_modified': 'Sat, 21 Dec 2024 04:35:02 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.nightly.munki/downloads/FileZilla_nightly.tar.bz2',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.nightly.munki/downloads/FileZilla_nightly.tar.bz2'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'purge_destination': True}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'tar_bzip2' from filename FileZilla_nightly.tar.bz2
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.nightly.munki/downloads/FileZilla_nightly.tar.bz2 to ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.nightly.munki/FileZilla_nightly
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.nightly.munki/FileZilla_nightly/FileZilla.app',
           'requirement': 'identifier "org.filezilla-project.filezilla" and '
                          'anchor apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"5VPGKXL75N"'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.nightly.munki/FileZilla_nightly/FileZilla.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.nightly.munki/FileZilla_nightly/FileZilla.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.nightly.munki/FileZilla_nightly/FileZilla.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Unarchiver
{'Input': {'USE_PYTHON_NATIVE_EXTRACTOR': False,
           'archive_path': '~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.nightly.munki/downloads/FileZilla_nightly.tar.bz2',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.nightly.munki/FileZilla_nightly',
           'purge_destination': True}}
Unarchiver: Guessed archive format 'tar_bzip2' from filename FileZilla_nightly.tar.bz2
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.nightly.munki/downloads/FileZilla_nightly.tar.bz2 to ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.nightly.munki/FileZilla_nightly
{'Output': {}}
DmgCreator
{'Input': {'dmg_path': '~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.nightly.munki/FileZilla_nightly.dmg',
           'dmg_root': '~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.nightly.munki/FileZilla_nightly'}}
DmgCreator: Created dmg from ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.nightly.munki/FileZilla_nightly at ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.nightly.munki/FileZilla_nightly.dmg
{'Output': {}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/Users/Shared/munki_repo',
           'pkg_path': '~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.nightly.munki/FileZilla_nightly.dmg',
           'pkginfo': {'catalogs': ['testing'],
                       'display_name': 'FileZilla',
                       'name': 'FileZilla_nightly',
                       'unattended_install': True},
           'repo_subdirectory': 'apps/FileZilla/nightly'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/FileZilla/nightly/FileZilla_nightly-3.68.1__1.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/FileZilla/nightly/FileZilla_nightly-3.68.1__1.dmg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': 'testing',
                                                       'icon_repo_path': '',
                                                       'name': 'FileZilla_nightly',
                                                       'pkg_repo_path': 'apps/FileZilla/nightly/FileZilla_nightly-3.68.1__1.dmg',
                                                       'pkginfo_path': 'apps/FileZilla/nightly/FileZilla_nightly-3.68.1__1.plist',
                                                       'version': '3.68.1'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path',
                                                                'icon_repo_path'],
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'imported into '
                                                              'Munki:'},
            'munki_info': {'_metadata': {'created_by': 'testuser',
                                         'creation_date': datetime.datetime(2024, 12, 30, 21, 45, 9),
                                         'munki_version': '6.6.3.4704',
                                         'os_version': '15.2'},
                           'autoremove': False,
                           'catalogs': ['testing'],
                           'display_name': 'FileZilla',
                           'installer_item_hash': 'cfb2cccaf7f568928a23a824f34ba89778c6f19e921340a4cf187969da46fd76',
                           'installer_item_location': 'apps/FileZilla/nightly/FileZilla_nightly-3.68.1__1.dmg',
                           'installer_item_size': 16560,
                           'installer_type': 'copy_from_dmg',
                           'installs': [{'CFBundleIdentifier': 'org.filezilla-project.filezilla',
                                         'CFBundleName': 'FileZilla',
                                         'CFBundleShortVersionString': '3.68.1',
                                         'CFBundleVersion': '3.68.1',
                                         'minosversion': '10.13.2',
                                         'path': '/Applications/FileZilla.app',
                                         'type': 'application',
                                         'version_comparison_key': 'CFBundleShortVersionString'}],
                           'items_to_copy': [{'destination_path': '/Applications',
                                              'source_item': 'FileZilla.app'}],
                           'minimum_os_version': '10.13.2',
                           'name': 'FileZilla_nightly',
                           'unattended_install': True,
                           'uninstall_method': 'remove_copied_items',
                           'uninstallable': True,
                           'version': '3.68.1'},
            'munki_repo_changed': True,
            'pkg_repo_path': '/Users/Shared/munki_repo/pkgs/apps/FileZilla/nightly/FileZilla_nightly-3.68.1__1.dmg',
            'pkginfo_repo_path': '/Users/Shared/munki_repo/pkgsinfo/apps/FileZilla/nightly/FileZilla_nightly-3.68.1__1.plist'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.nightly.munki/receipts/FileZilla_nightly.munki-receipt-20241230-134509.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.nightly.download/downloads/FileZilla_nightly.tar.bz2
    ~/Library/AutoPkg/Cache/com.github.keeleysam.recipes.FileZilla.nightly.munki/downloads/FileZilla_nightly.tar.bz2

The following new items were imported into Munki:
    Name               Version  Catalogs  Pkginfo Path                                              Pkg Repo Path                                           Icon Repo Path
    ----               -------  --------  ------------                                              -------------                                           --------------
    FileZilla_nightly  3.68.1   testing   apps/FileZilla/nightly/FileZilla_nightly-3.68.1__1.plist  apps/FileZilla/nightly/FileZilla_nightly-3.68.1__1.dmg
```

