### PR TITLE
Deprecate Parallels recipes for version 10 and lower

### DIFF
--- a/ParallelsDesktop/ParallelsDesktop.download.recipe
+++ b/ParallelsDesktop/ParallelsDesktop.download.recipe
@@ -9,9 +9,18 @@
 	<key>Input</key>
 	<dict/>
 	<key>MinimumVersion</key>
-	<string>0.2.1</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>Consider switching to the ParallelsDesktop recipes in the homebysix-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>


### PR DESCRIPTION
This PR deprecates the Parallels recipes in this repo and points users to newer Parallels recipes in my homebysix-recipes repo, which support version 10 and above.