### PR TITLE
Add DeprecationWarning for FileZilla recipes

### DIFF
--- a/FileZilla/FileZilla.download.recipe
+++ b/FileZilla/FileZilla.download.recipe
@@ -26,6 +26,15 @@ Note the architecture values are not the same as the FileZilla nightly recipe.
 	<key>Process</key>
 	<array>
 		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>These FileZilla recipes are deprecated and will be removed in the future. If you still need to deploy FileZilla, alternatives exist here: https://github.com/pappirauk/svs-recipes/tree/main/FileZilla</string>
+			</dict>
+		</dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>re_pattern</key>


### PR DESCRIPTION
This PR deprecates the non-working FileZilla recipes and points to alternatives that currently require playwright to be installed.