### PR TITLE
Update Zulip AutoPkg recipes for arch & signing

### DIFF
--- a/Zulip/Zulip.download.recipe
+++ b/Zulip/Zulip.download.recipe
@@ -3,18 +3,21 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads latest Zulip disk image.</string>
+	<string>Downloads latest Zulip disk image.
+
+To download Apple Silicon use: "arm64" in the DOWNLOAD_ARCH variable
+To download Intel use: "intel" in the DOWNLOAD_ARCH variable</string>
 	<key>Identifier</key>
 	<string>com.github.keeleysam.recipes.zulip.download</string>
 	<key>Input</key>
 	<dict>
-		<key>DOWNLOAD_URL</key>
-		<string>https://zulip.com/dist/apps/mac/Zulip-latest.dmg</string>
+		<key>DOWNLOAD_ARCH</key>
+		<string>arm64</string>
 		<key>NAME</key>
 		<string>Zulip</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.0</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
 		<dict>
@@ -23,7 +26,7 @@
 				<key>filename</key>
 				<string>%NAME%.dmg</string>
 				<key>url</key>
-				<string>%DOWNLOAD_URL%</string>
+				<string>https://zulip.com/apps/download/mac-%DOWNLOAD_ARCH%</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>
@@ -31,6 +34,17 @@
 		<dict>
 			<key>Processor</key>
 			<string>EndOfCheckPhase</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>input_path</key>
+				<string>%pathname%/Zulip.app</string>
+				<key>requirement</key>
+				<string>identifier "org.zulip.zulip-electron" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "66KHCWMEYB"</string>
+			</dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
 		</dict>
 	</array>
 </dict>

--- a/Zulip/Zulip.munki.recipe
+++ b/Zulip/Zulip.munki.recipe
@@ -3,15 +3,20 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest Zulip disk image and imports into Munki.</string>
+	<string>Downloads the latest Zulip disk image and imports into Munki.
+
+For Intel use: "x86_64" in the SUPPORTED_ARCH variable
+For Apple Silicon use: "arm64" in the SUPPORTED_ARCH variable</string>
 	<key>Identifier</key>
 	<string>com.github.keeleysam.recipes.zulip.munki</string>
 	<key>Input</key>
 	<dict>
 		<key>MUNKI_REPO_SUBDIR</key>
-		<string>apps/Dropbox/Zulip</string>
+		<string>apps/Kandra Labs/Zulip</string>
 		<key>NAME</key>
 		<string>Zulip</string>
+		<key>SUPPORTED_ARCH</key>
+		<string>arm64</string>
 		<key>pkginfo</key>
 		<dict>
 			<key>catalogs</key>
@@ -20,16 +25,24 @@
 			</array>
 			<key>category</key>
 			<string>Social Networking</string>
+			<key>description</key>
+			<string>Organized chat for distributed teams</string>
 			<key>developer</key>
-			<string>Dropbox</string>
+			<string>Kandra Labs, Inc.</string>
 			<key>name</key>
 			<string>%NAME%</string>
+			<key>supported_architectures</key>
+			<array>
+				<string>%SUPPORTED_ARCH%</string>
+			</array>
 			<key>unattended_install</key>
+			<true/>
+			<key>unattended_uninstall</key>
 			<true/>
 		</dict>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.0</string>
+	<string>1.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.keeleysam.recipes.zulip.download</string>
 	<key>Process</key>


### PR DESCRIPTION
Hi, @keeleysam 

The Zulip recipes are currently failing in their default state with the below error 
```
The following recipes failed:
    Zulip.munki.recipe
        Error in com.github.keeleysam.recipes.zulip.munki: Processor: URLDownloader: Error: curl: (56) The requested URL returned error: 404

Nothing downloaded, packaged or imported.
```

This PR adds  architecture support and CodeSignatureVerifier 

Output from a successful -v run 
```
autopkg run -v Zulip.munki.recipe
Processing Zulip.munki.recipe...
WARNING: Zulip.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
URLDownloader: Storing new Last-Modified header: Fri, 12 Dec 2025 22:45:23 GMT
URLDownloader: Storing new ETag header: "0x8DE39D023164A19"
URLDownloader: Downloaded /Users/paul.cossey/Library/AutoPkg/Cache/com.github.keeleysam.recipes.zulip.munki/downloads/Zulip.dmg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.keeleysam.recipes.zulip.munki/downloads/Zulip.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.ZPep2I/Zulip.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.ZPep2I/Zulip.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.ZPep2I/Zulip.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/Kandra Labs/Zulip/Zulip-5.12.3.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/Kandra Labs/Zulip/Zulip-5.12.3.dmg
Receipt written to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.keeleysam.recipes.zulip.munki/receipts/Zulip.munki-receipt-20260203-102648.plist

The following new items were downloaded:
    Download Path                                                                                          
    -------------                                                                                          
    /Users/paul.cossey/Library/AutoPkg/Cache/com.github.keeleysam.recipes.zulip.munki/downloads/Zulip.dmg  

The following new items were imported into Munki:
    Name   Version  Catalogs    Pkginfo Path                               Pkg Repo Path                            Icon Repo Path  
    ----   -------  --------    ------------                               -------------                            --------------  
    Zulip  5.12.3   production  apps/Kandra Labs/Zulip/Zulip-5.12.3.plist  apps/Kandra Labs/Zulip/Zulip-5.12.3.dmg
```