### PR TITLE
Deprecate Handbrake download recipe

### DIFF
--- a/Handbrake/Handbrake.download.recipe
+++ b/Handbrake/Handbrake.download.recipe
@@ -6,6 +6,8 @@
 	<string>Downloads the current release version of HandBrake.</string>
 	<key>Identifier</key>
 	<string>com.github.keeleysam.autopkg.download.HandBrake</string>
+	<key>MinimumVersion</key>
+	<string>1.1</string>
 	<key>Input</key>
 	<dict>
 		<key>NAME</key>
@@ -15,6 +17,15 @@
 	</dict>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>This recipe has been deprecated. Please use com.github.autopkg.download.Handbrake from the recipes repo instead, which has code signature verification and uses GitHub Releases instead of a Sparkle feed.</string>
+			</dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>

--- a/Handbrake/Handbrake.munki.recipe
+++ b/Handbrake/Handbrake.munki.recipe
@@ -29,7 +29,7 @@
 		</dict>
 	</dict>
 	<key>ParentRecipe</key>
-	<string>com.github.keeleysam.autopkg.download.HandBrake</string>
+	<string>com.github.autopkg.download.Handbrake</string>
 	<key>Process</key>
 	<array>
 		<dict>


### PR DESCRIPTION
The recipes repo has a Handbrake download recipe (com.github.autopkg.download.Handbrake) that uses GitHub Releases instead of a Sparkle feed and includes code signature verification.

- Add DeprecationWarning to the download recipe
- Re-parent the munki recipe to use the recipes repo download
- Set MinimumVersion to 1.1 (required for DeprecationWarning)