### PR TITLE
Remove unused distutils import

### DIFF
--- a/ParallelsDesktop/ParallelsURLProvider.py
+++ b/ParallelsDesktop/ParallelsURLProvider.py
@@ -19,7 +19,6 @@
 from __future__ import absolute_import
 
 import xml.dom.minidom
-from distutils.version import LooseVersion
 
 from autopkglib import Processor, ProcessorError, URLGetter
 


### PR DESCRIPTION
`ParallelsURLProvider.py` imports `distutils.version.LooseVersion` but never uses it.

This PR removes the dead import so the processor does not break on a future version of AutoPkg that includes a Python 3.12 or 3.13 runtime and drops `distutils`. There is no functional change.
